### PR TITLE
Make UrlBuilder attributes private

### DIFF
--- a/Imgix-CSharp-Tests/ImgixBlueprintTests.cs
+++ b/Imgix-CSharp-Tests/ImgixBlueprintTests.cs
@@ -18,7 +18,7 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderHandlesBasicPathsProperly()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/users/1.png", test.BuildUrl("/users/1.png"));
         }
@@ -26,7 +26,7 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderDoesnotMerelyAppend()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
 
             Assert.AreNotEqual("https://my-social-network.imgix.net/http://avatars.com/john-smith.png", test.BuildUrl("http://avatars.com/john-smith.png"));
         }
@@ -34,7 +34,7 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderProperlyEncodesAbsolutePaths()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png", test.BuildUrl("http://avatars.com/john-smith.png"));
         }
@@ -42,21 +42,19 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderAppendsQueryStringParameters()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
 
-            test.Parameters.Add("w", "400");
-            test.Parameters.Add("h", "300");
+            var parameters = new Dictionary<String, String>();
+            parameters.Add("w", "400");
+            parameters.Add("h", "300");
 
-            Assert.AreEqual("https://my-social-network.imgix.net/users/1.png?w=400&h=300", test.BuildUrl("/users/1.png"));
+            Assert.AreEqual("https://my-social-network.imgix.net/users/1.png?w=400&h=300", test.BuildUrl("/users/1.png", parameters));
         }
 
         [Test]
         public void UrlBuilderProperlySignsSimpleRequests()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true)
-            {
-                SignKey = "FOO123bar"
-            };
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey: "FOO123bar", signWithLibrary: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/users/1.png?s=6797c24146142d5b40bde3141fd3600c", test.BuildUrl("/users/1.png"));
         }
@@ -64,10 +62,7 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderProperlySignsFullyQualifiedUrls()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true)
-            {
-                SignKey = "FOO123bar"
-            };
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey:  "FOO123bar", signWithLibrary: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?s=493a52f008c91416351f8b33d4883135", test.BuildUrl("/http%3A%2F%2Favatars.com%2Fjohn-smith.png"));
         }
@@ -75,29 +70,27 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderProperlySignsSimplePathsWithParameters()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true)
-            {
-                SignKey = "FOO123bar"
-            };
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey:  "FOO123bar", signWithLibrary: false);
 
-            test.Parameters.Add("w", "400");
-            test.Parameters.Add("h", "300");
+            var parameters = new Dictionary<String, String>();
+            parameters.Add("w", "400");
+            parameters.Add("h", "300");
 
-            Assert.AreEqual("https://my-social-network.imgix.net/users/1.png?w=400&h=300&s=c7b86f666a832434dd38577e38cf86d1", test.BuildUrl("/users/1.png"));
+            Assert.AreEqual("https://my-social-network.imgix.net/users/1.png?w=400&h=300&s=c7b86f666a832434dd38577e38cf86d1",
+                            test.BuildUrl("/users/1.png", parameters));
         }
 
         [Test]
         public void UrlBuilderProperlySignsFullyQualifiedUrlsWithParameters()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true)
-            {
-                SignKey = "FOO123bar"
-            };
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey: "FOO123bar", signWithLibrary: false);
 
-            test.Parameters.Add("w", "400");
-            test.Parameters.Add("h", "300");
+            var parameters = new Dictionary<String, String>();
+            parameters.Add("w", "400");
+            parameters.Add("h", "300");
 
-            Assert.AreEqual("https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=61ea1cc7add87653bb0695fe25f2b534", test.BuildUrl("/http%3A%2F%2Favatars.com%2Fjohn-smith.png"));
+            Assert.AreEqual("https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=61ea1cc7add87653bb0695fe25f2b534",
+                            test.BuildUrl("/http%3A%2F%2Favatars.com%2Fjohn-smith.png", parameters));
         }
     }
 }

--- a/Imgix-CSharp-Tests/UrlBuilderTest.cs
+++ b/Imgix-CSharp-Tests/UrlBuilderTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Imgix;
 using NUnit.Framework;
@@ -13,15 +14,15 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderBuildsBasicUrlHttp()
         {
-            var test = new UrlBuilder("domain.imgix.net");
+            var test = new UrlBuilder("domain.imgix.net", signWithLibrary: false);
 
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain.imgix.net/gaiman.jpg");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
         }
 
         [Test]
         public void UrlBuilderBuildsBasicUrlHttps()
         {
-            var test = new UrlBuilder("domain.imgix.net", useHttps: true);
+            var test = new UrlBuilder("domain.imgix.net", useHttps: true, signWithLibrary: false);
 
             Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
         }
@@ -29,67 +30,102 @@ namespace Imgix_Tests
         [Test]
         public void UrlBuilderBuildsQueryStringUrlHttp()
         {
-            var test = new UrlBuilder("domain.imgix.net");
+            var test = new UrlBuilder("domain.imgix.net", signWithLibrary: false);
 
-            test.Parameters["w"] = "500";
-            test.Parameters["blur"] = "100";
+            var parameters = new Dictionary<String, String>();
+            parameters["w"] = "500";
+            parameters["blur"] = "100";
 
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain.imgix.net/gaiman.jpg?w=500&blur=100");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg", parameters), "https://domain.imgix.net/gaiman.jpg?w=500&blur=100");
         }
 
         [Test]
         public void UrlBuilderBuildsQueryStringUrlHttps()
         {
-            var test = new UrlBuilder("domain.imgix.net", useHttps: true);
+            var test = new UrlBuilder("domain.imgix.net", useHttps: true, signWithLibrary: false);
 
-            test.Parameters["w"] = "500";
-            test.Parameters["blur"] = "100";
+            var parameters = new Dictionary<String, String>();
+            parameters["w"] = "500";
+            parameters["blur"] = "100";
 
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg?w=500&blur=100");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg", parameters), "https://domain.imgix.net/gaiman.jpg?w=500&blur=100");
         }
 
         [Test]
         public void UrlBuilderUsesCRCShardingBydefault()
         {
-            var test = new UrlBuilder("domain.imgix.net", useHttps: true);
+            var domains = new [] { "domain1.imgix.net",  "domain2.imgix.net" };
+            var test = new UrlBuilder(domains, signWithLibrary: false);
 
-            Assert.AreEqual(test.ShardStrategy, UrlBuilder.ShardStrategyType.CRC);
+            Assert.True(test.BuildUrl("/users/1.png").Contains(domains[0]));
+            Assert.True(test.BuildUrl("/users/1.png").Contains(domains[0]));
+            Assert.True(test.BuildUrl("/users/2.png").Contains(domains[0]));
+            Assert.True(test.BuildUrl("/users/2.png").Contains(domains[0]));
+            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
+            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
+            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
+            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
+        }
+
+        [Test]
+        public void UrlBuilderClonesDomainList()
+        {
+            var domains = new[] { "domain1.imgix.net", "domain2.imgix.net" };
+            var test = new UrlBuilder(domains, signWithLibrary: false);
+            domains[0] = "domain3.imgix.net";
+            domains[1] = "domain4.imgix.net";
+
+            Assert.False(test.BuildUrl("/users/1.png").Contains(domains[0]));
+            Assert.False(test.BuildUrl("/users/1.png").Contains(domains[0]));
+            Assert.False(test.BuildUrl("/users/2.png").Contains(domains[0]));
+            Assert.False(test.BuildUrl("/users/2.png").Contains(domains[0]));
+            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
+            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
+            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
+            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
         }
 
         [Test]
         public void UrlBuilderSignsParameterlessRequests()
         {
-            var test = new UrlBuilder("domain.imgix.net")
-            {
-                SignKey = SignKey
-            };
+            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, signWithLibrary: false);
 
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain.imgix.net/gaiman.jpg?s=db6110637ad768e4b1d503cb96e6439a");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg?s=db6110637ad768e4b1d503cb96e6439a");
         }
 
         [Test]
         public void UrlBuilderSignsParameteredRequests()
         {
-            var test = new UrlBuilder("domain.imgix.net")
-            {
-                SignKey = SignKey
-            };
+            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, signWithLibrary: false);
 
-            test.Parameters.Add("w", "500");
-            test.Parameters.Add("h", "1000");
+            var parameters = new Dictionary<String, String>();
+            parameters.Add("w", "500");
+            parameters.Add("h", "1000");
 
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain.imgix.net/gaiman.jpg?w=500&h=1000&s=fc4afbc39b6741560717142aeada876c");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg", parameters), "https://domain.imgix.net/gaiman.jpg?w=500&h=1000&s=fc4afbc39b6741560717142aeada876c");
         }
 
         [Test]
         public void UrlBuilderSignsNestedPaths()
         {
-            var test = new UrlBuilder("domain.imgix.net")
+            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, signWithLibrary: false);
+
+            Assert.AreEqual(test.BuildUrl("test/gaiman.jpg"), "https://domain.imgix.net/test/gaiman.jpg?s=51033c27726f19c0f8229a1ed2dc8523");
+        }
+
+        [Test]
+        public void UrlBuilderWithMultipleDomainsPicksTheFirstWhenShardTypeNull()
+        {
+            var domains = new[] { "domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net" };
+
+            var test = new UrlBuilder(domains, signWithLibrary: false)
             {
-                SignKey = SignKey
+                ShardStrategy = null
             };
 
-            Assert.AreEqual(test.BuildUrl("test/gaiman.jpg"), "http://domain.imgix.net/test/gaiman.jpg?s=51033c27726f19c0f8229a1ed2dc8523");
+            Assert.AreEqual(test.BuildUrl("/users/1.png"), "https://domain.imgix.net/users/1.png");
+            Assert.AreEqual(test.BuildUrl("/users/2.png"), "https://domain.imgix.net/users/2.png");
+            Assert.AreEqual(test.BuildUrl("/users/a.png"), "https://domain.imgix.net/users/a.png");
         }
 
         [Test]
@@ -97,28 +133,12 @@ namespace Imgix_Tests
         {
             var domains = new[] {"domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net"};
 
-            var test = new UrlBuilder(domains)
-            {
-                ShardStrategy = UrlBuilder.ShardStrategyType.CYCLE
-            };
+            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CYCLE, signWithLibrary: false);
 
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain.imgix.net/gaiman.jpg");
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain2.imgix.net/gaiman.jpg");
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain3.imgix.net/gaiman.jpg");
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain.imgix.net/gaiman.jpg");
-        }
-
-        [Test]
-        public void UrlBuilderWithMultipleDomainsPicksTheFirstWhenNoShardTypeSelected()
-        {
-            var domains = new[] { "domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net" };
-
-            var test = new UrlBuilder(domains)
-            {
-                ShardStrategy = null
-            };
-
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "http://domain.imgix.net/gaiman.jpg");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain2.imgix.net/gaiman.jpg");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain3.imgix.net/gaiman.jpg");
+            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
         }
 
         [Test]
@@ -127,44 +147,44 @@ namespace Imgix_Tests
             var domains = new[] { "domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net" };
             var crcs = new [] { "test1.png", "test2.png", "test3.png" }.Select(i => Convert.ToInt32(new Crc32().ComputeCrcHash(i) % domains.Length)).ToArray();
 
-            var test = new UrlBuilder(domains)
-            {
-                ShardStrategy = UrlBuilder.ShardStrategyType.CRC
-            };
+            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CRC, signWithLibrary: false);
 
-            Assert.AreEqual(test.BuildUrl("test1.png"), String.Format("http://{0}/test1.png", domains[crcs[0]]));
-            Assert.AreEqual(test.BuildUrl("test2.png"), String.Format("http://{0}/test2.png", domains[crcs[1]]));
-            Assert.AreEqual(test.BuildUrl("test3.png"), String.Format("http://{0}/test3.png", domains[crcs[2]]));
+            Assert.AreEqual(test.BuildUrl("test1.png"), String.Format("https://{0}/test1.png", domains[crcs[0]]));
+            Assert.AreEqual(test.BuildUrl("test2.png"), String.Format("https://{0}/test2.png", domains[crcs[1]]));
+            Assert.AreEqual(test.BuildUrl("test3.png"), String.Format("https://{0}/test3.png", domains[crcs[2]]));
         }
 
         [Test]
         public void UrlBuilderEscapesParamKeys()
         {
-            var test = new UrlBuilder("demo.imgix.net");
+            var test = new UrlBuilder("demo.imgix.net", signWithLibrary: false);
 
-            test.Parameters["hello world"] = "interesting";
+            var parameters = new Dictionary<String, String>();
+            parameters["hello world"] = "interesting";
 
-            Assert.AreEqual("http://demo.imgix.net/demo.png?hello%20world=interesting", test.BuildUrl("demo.png"));
+            Assert.AreEqual("https://demo.imgix.net/demo.png?hello%20world=interesting", test.BuildUrl("demo.png", parameters));
         }
 
         [Test]
         public void UrlBuilderEscapesParamValues()
         {
-            var test = new UrlBuilder("demo.imgix.net");
+            var test = new UrlBuilder("demo.imgix.net", signWithLibrary: false);
 
-            test.Parameters["hello_world"] = "/foo\"> <script>alert(\"hacked\")</script><";
+            var parameters = new Dictionary<String, String>();
+            parameters["hello_world"] = "/foo\"> <script>alert(\"hacked\")</script><";
 
-            Assert.AreEqual("http://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C", test.BuildUrl("demo.png"));
+            Assert.AreEqual("https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C", test.BuildUrl("demo.png", parameters));
         }
 
         [Test]
         public void UrlBuilderBase64EncodesBase64ParamVariants()
         {
-            var test = new UrlBuilder("demo.imgix.net");
+            var test = new UrlBuilder("demo.imgix.net", signWithLibrary: false);
 
-            test.Parameters["txt64"] = "I cannøt belîév∑ it wors! \ud83d\ude31";
+            var parameters = new Dictionary<String, String>();
+            parameters["txt64"] = "I cannøt belîév∑ it wors! \ud83d\ude31";
 
-            Assert.AreEqual("http://demo.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE", test.BuildUrl("~text"));
+            Assert.AreEqual("https://demo.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE", test.BuildUrl("~text", parameters));
         }
     }
 }


### PR DESCRIPTION
Make `SignKey` and `Domains` attributes private. Update constructors.