### PR TITLE
Rename ixlib param to `includeLibraryParam`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ using Imgix;
 var builder = new UrlBuilder("domain.imgix.net")
 {
     SignKey = "aaAAbbBB11223344",
-    SignWithLibrary = false
+    IncludeLibraryParam = false
 };
 var parameters = new Dictionary<String, String>();
 parameters["w"] = "500";
@@ -84,12 +84,12 @@ By default, shards are calculated using a checksum so that the image path always
 
 For security and diagnostic purposes, we sign all requests with the language and version of library used to generate the URL.
 
-This can be disabled by passing `false` for the `signWithLibrary` option to `new UrlBuilder`:
+This can be disabled by passing `false` for the `includeLibraryParam` option to `new UrlBuilder`:
 
 ```csharp
 using Imgix;
 ...
-var builder = new UrlBuilder("domain.imgix.net", signWithLibrary: false);
+var builder = new UrlBuilder("domain.imgix.net", includeLibraryParam: false);
 ```
 
 ## Code of Conduct

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -16,7 +16,7 @@ namespace Imgix
         }
 
         public Boolean UseHttps;
-        public Boolean SignWithLibrary;
+        public Boolean IncludeLibraryParam;
         public ShardStrategyType? ShardStrategy;
 
         private String _signKey;
@@ -29,24 +29,24 @@ namespace Imgix
         public UrlBuilder(String[] domains,
                           String signKey = null,
                           ShardStrategyType shardStrategy = ShardStrategyType.CRC,
-                          Boolean signWithLibrary = true,
+                          Boolean includeLibraryParam = true,
                           Boolean useHttps = true)
         {
             Domains = (String []) domains.Clone();
             _signKey = signKey;
             ShardStrategy = shardStrategy;
-            SignWithLibrary = signWithLibrary;
+            IncludeLibraryParam = includeLibraryParam;
             UseHttps = useHttps;
         }
 
         public UrlBuilder(String domain,
                           String signKey = null,
-                          Boolean signWithLibrary = true,
+                          Boolean includeLibraryParam = true,
                           Boolean useHttps = true)
             : this(new[] { domain },
                    signKey: signKey,
                    useHttps: useHttps,
-                   signWithLibrary: signWithLibrary)
+                   includeLibraryParam: includeLibraryParam)
         {
         }
 
@@ -61,12 +61,12 @@ namespace Imgix
         }
 
         public UrlBuilder(String domain, String signKey, Boolean useHttps)
-            : this(domain, signKey: signKey, signWithLibrary: true, useHttps: useHttps)
+            : this(domain, signKey: signKey, includeLibraryParam: true, useHttps: useHttps)
         {
         }
 
         public UrlBuilder(String[] domains, String signKey, Boolean useHttps)
-            : this(domains, signKey: signKey, signWithLibrary: true, useHttps: useHttps)
+            : this(domains, signKey: signKey, includeLibraryParam: true, useHttps: useHttps)
         {
         }
 
@@ -99,7 +99,7 @@ namespace Imgix
 
             var domain = Domains[index];
 
-            if (SignWithLibrary)
+            if (IncludeLibraryParam)
             {
                 parameters.Add("ixlib", String.Format("csharp-{0}", typeof(UrlBuilder).GetTypeInfo().Assembly.GetName().Version));
             }

--- a/tests/Imgix.Tests/ImgixBlueprintTests.cs
+++ b/tests/Imgix.Tests/ImgixBlueprintTests.cs
@@ -18,7 +18,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderHandlesBasicPathsProperly()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, includeLibraryParam: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/users/1.png", test.BuildUrl("/users/1.png"));
         }
@@ -26,7 +26,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderDoesnotMerelyAppend()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, includeLibraryParam: false);
 
             Assert.AreNotEqual("https://my-social-network.imgix.net/http://avatars.com/john-smith.png", test.BuildUrl("http://avatars.com/john-smith.png"));
         }
@@ -34,7 +34,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderProperlyEncodesAbsolutePaths()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, includeLibraryParam: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png", test.BuildUrl("http://avatars.com/john-smith.png"));
         }
@@ -42,7 +42,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderAppendsQueryStringParameters()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters.Add("w", "400");
@@ -54,7 +54,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderProperlySignsSimpleRequests()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey: "FOO123bar", signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey: "FOO123bar", includeLibraryParam: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/users/1.png?s=6797c24146142d5b40bde3141fd3600c", test.BuildUrl("/users/1.png"));
         }
@@ -62,7 +62,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderProperlySignsFullyQualifiedUrls()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey:  "FOO123bar", signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey:  "FOO123bar", includeLibraryParam: false);
 
             Assert.AreEqual("https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?s=493a52f008c91416351f8b33d4883135", test.BuildUrl("/http%3A%2F%2Favatars.com%2Fjohn-smith.png"));
         }
@@ -70,7 +70,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderProperlySignsSimplePathsWithParameters()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey:  "FOO123bar", signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey:  "FOO123bar", includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters.Add("w", "400");
@@ -83,7 +83,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderProperlySignsFullyQualifiedUrlsWithParameters()
         {
-            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey: "FOO123bar", signWithLibrary: false);
+            var test = new UrlBuilder("my-social-network.imgix.net", useHttps: true, signKey: "FOO123bar", includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters.Add("w", "400");

--- a/tests/Imgix.Tests/UrlBuilderTest.cs
+++ b/tests/Imgix.Tests/UrlBuilderTest.cs
@@ -14,7 +14,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderBuildsBasicUrlHttp()
         {
-            var test = new UrlBuilder("domain.imgix.net", signWithLibrary: false);
+            var test = new UrlBuilder("domain.imgix.net", includeLibraryParam: false);
 
             Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
         }
@@ -22,7 +22,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderBuildsBasicUrlHttps()
         {
-            var test = new UrlBuilder("domain.imgix.net", useHttps: true, signWithLibrary: false);
+            var test = new UrlBuilder("domain.imgix.net", useHttps: true, includeLibraryParam: false);
 
             Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
         }
@@ -30,7 +30,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderBuildsQueryStringUrlHttp()
         {
-            var test = new UrlBuilder("domain.imgix.net", signWithLibrary: false);
+            var test = new UrlBuilder("domain.imgix.net", includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters["w"] = "500";
@@ -42,7 +42,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderBuildsQueryStringUrlHttps()
         {
-            var test = new UrlBuilder("domain.imgix.net", useHttps: true, signWithLibrary: false);
+            var test = new UrlBuilder("domain.imgix.net", useHttps: true, includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters["w"] = "500";
@@ -55,7 +55,7 @@ namespace Imgix.Tests
         public void UrlBuilderUsesCRCShardingBydefault()
         {
             var domains = new [] { "domain1.imgix.net",  "domain2.imgix.net" };
-            var test = new UrlBuilder(domains, signWithLibrary: false);
+            var test = new UrlBuilder(domains, includeLibraryParam: false);
 
             Assert.True(test.BuildUrl("/users/1.png").Contains(domains[0]));
             Assert.True(test.BuildUrl("/users/1.png").Contains(domains[0]));
@@ -71,7 +71,7 @@ namespace Imgix.Tests
         public void UrlBuilderClonesDomainList()
         {
             var domains = new[] { "domain1.imgix.net", "domain2.imgix.net" };
-            var test = new UrlBuilder(domains, signWithLibrary: false);
+            var test = new UrlBuilder(domains, includeLibraryParam: false);
             domains[0] = "domain3.imgix.net";
             domains[1] = "domain4.imgix.net";
 
@@ -88,7 +88,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderSignsParameterlessRequests()
         {
-            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, signWithLibrary: false);
+            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, includeLibraryParam: false);
 
             Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg?s=db6110637ad768e4b1d503cb96e6439a");
         }
@@ -96,7 +96,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderSignsParameteredRequests()
         {
-            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, signWithLibrary: false);
+            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters.Add("w", "500");
@@ -108,7 +108,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderSignsNestedPaths()
         {
-            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, signWithLibrary: false);
+            var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, includeLibraryParam: false);
 
             Assert.AreEqual(test.BuildUrl("test/gaiman.jpg"), "https://domain.imgix.net/test/gaiman.jpg?s=51033c27726f19c0f8229a1ed2dc8523");
         }
@@ -118,7 +118,7 @@ namespace Imgix.Tests
         {
             var domains = new[] { "domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net" };
 
-            var test = new UrlBuilder(domains, signWithLibrary: false)
+            var test = new UrlBuilder(domains, includeLibraryParam: false)
             {
                 ShardStrategy = null
             };
@@ -133,7 +133,7 @@ namespace Imgix.Tests
         {
             var domains = new[] {"domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net"};
 
-            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CYCLE, signWithLibrary: false);
+            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CYCLE, includeLibraryParam: false);
 
             Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
             Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain2.imgix.net/gaiman.jpg");
@@ -147,7 +147,7 @@ namespace Imgix.Tests
             var domains = new[] { "domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net" };
             var crcs = new [] { "test1.png", "test2.png", "test3.png" }.Select(i => Convert.ToInt32(new Crc32().ComputeCrcHash(i) % domains.Length)).ToArray();
 
-            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CRC, signWithLibrary: false);
+            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CRC, includeLibraryParam: false);
 
             Assert.AreEqual(test.BuildUrl("test1.png"), String.Format("https://{0}/test1.png", domains[crcs[0]]));
             Assert.AreEqual(test.BuildUrl("test2.png"), String.Format("https://{0}/test2.png", domains[crcs[1]]));
@@ -157,7 +157,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderEscapesParamKeys()
         {
-            var test = new UrlBuilder("demo.imgix.net", signWithLibrary: false);
+            var test = new UrlBuilder("demo.imgix.net", includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters["hello world"] = "interesting";
@@ -168,7 +168,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderEscapesParamValues()
         {
-            var test = new UrlBuilder("demo.imgix.net", signWithLibrary: false);
+            var test = new UrlBuilder("demo.imgix.net", includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters["hello_world"] = "/foo\"> <script>alert(\"hacked\")</script><";
@@ -179,7 +179,7 @@ namespace Imgix.Tests
         [Test]
         public void UrlBuilderBase64EncodesBase64ParamVariants()
         {
-            var test = new UrlBuilder("demo.imgix.net", signWithLibrary: false);
+            var test = new UrlBuilder("demo.imgix.net", includeLibraryParam: false);
 
             var parameters = new Dictionary<String, String>();
             parameters["txt64"] = "I cannøt belîév∑ it wors! \ud83d\ude31";


### PR DESCRIPTION
`includeLibraryParam` is the standard parameter across other imgix libraries for controlling `ixlib=<library>-<version>` URL parameter. This PR renames `signWithLibrary`/`SignWithLibrary` to `includeLibraryParam`/`IncludeLibraryParam` respectively to be consistent with other libraries.