### PR TITLE
fix: modify AssemblyInfo to reflect current version in ixlib param

### DIFF
--- a/src/Imgix/Properties/AssemblyInfo.cs
+++ b/src/Imgix/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Imgix.Tests/UrlBuilderTest.cs
+++ b/tests/Imgix.Tests/UrlBuilderTest.cs
@@ -186,5 +186,12 @@ namespace Imgix.Tests
 
             Assert.AreEqual("https://demo.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE", test.BuildUrl("~text", parameters));
         }
+
+        [Test]
+        public void UrlBuilderGeneratesIxLibParam()
+        {
+            var test = new UrlBuilder("demo.imgix.net", includeLibraryParam: true);
+            Assert.AreEqual(String.Format("https://demo.imgix.net/demo.png?ixlib=csharp-{0}", typeof(UrlBuilder).Assembly.GetName().Version), test.BuildUrl("demo.png"));
+        }
     }
 }


### PR DESCRIPTION
The `ixlib` parameter has not been reflecting the correct package version, despite the version being updated in `Imgix.csproj`. This PR modifies the `AssemblyInfo.cs` file to reflect the current package version, which is where the `ixlib` parameter value is generated from.