### PR TITLE
fix: deprecate domain sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Debug.Print(builder.BuildUrl("gaiman.jpg", parameters));
 ```
 
 ## Domain Sharded URLs
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release**<br>
+To find out more, see our [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding) explaining the decision to remove this feature.
 
 Domain sharding enables you to spread image requests across multiple domains. This allows you to bypass the requests-per-host limits of browsers. We recommend 2-3 domain shards maximum if you are going to use domain sharding.
 

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -26,6 +26,7 @@ namespace Imgix
 
         private int ShardCycleIndex = 0;
 
+        [Obsolete("Warning: Domain sharding has been deprecated and will be removed in the next major version.")]
         public UrlBuilder(String[] domains,
                           String signKey = null,
                           ShardStrategyType shardStrategy = ShardStrategyType.CRC,
@@ -55,6 +56,7 @@ namespace Imgix
         {
         }
 
+        [Obsolete("Warning: Domain sharding has been deprecated and will be removed in the next major version.")]
         public UrlBuilder(String[] domains, Boolean useHttps)
             : this(domains, signKey: null, useHttps: useHttps)
         {
@@ -65,6 +67,7 @@ namespace Imgix
         {
         }
 
+        [Obsolete("Warning: Domain sharding has been deprecated and will be removed in the next major version.")]
         public UrlBuilder(String[] domains, String signKey, Boolean useHttps)
             : this(domains, signKey: signKey, includeLibraryParam: true, useHttps: useHttps)
         {

--- a/tests/Imgix.Tests/UrlBuilderTest.cs
+++ b/tests/Imgix.Tests/UrlBuilderTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Imgix;
 using NUnit.Framework;
 
@@ -192,6 +193,34 @@ namespace Imgix.Tests
         {
             var test = new UrlBuilder("demo.imgix.net", includeLibraryParam: true);
             Assert.AreEqual(String.Format("https://demo.imgix.net/demo.png?ixlib=csharp-{0}", typeof(UrlBuilder).Assembly.GetName().Version), test.BuildUrl("demo.png"));
+        }
+
+        [Test]
+        public void UrlBuilderObsoleteConstructor1()
+        {
+            Type[] constructorParameters = new Type[] { typeof(String[]), typeof(String), typeof(UrlBuilder.ShardStrategyType),
+                                                        typeof(Boolean), typeof(Boolean) };
+            Assert.IsTrue(ConstructorHasObsoleteAttribute(constructorParameters));
+        }
+
+        [Test]
+        public void UrlBuilderObsoleteConstructor2()
+        {
+            Type[] constructorParameters = new Type[] { typeof(String[]), typeof(Boolean) };
+            Assert.IsTrue(ConstructorHasObsoleteAttribute(constructorParameters));
+        }
+
+        [Test]
+        public void UrlBuilderObsoleteConstructor3()
+        {
+            Type[] constructorParameters = new Type[] { typeof(String[]), typeof(String), typeof(Boolean) };
+            Assert.IsTrue(ConstructorHasObsoleteAttribute(constructorParameters));
+        }
+
+        private Boolean ConstructorHasObsoleteAttribute(Type[] constructorParameters)
+        {
+            ConstructorInfo ci = typeof(UrlBuilder).GetConstructor(constructorParameters);
+            return ci.GetCustomAttribute(typeof(ObsoleteAttribute)) != null;
         }
     }
 }


### PR DESCRIPTION
This PR begins the process of deprecating, and eventually removing, domain sharding from the imgix-csharp library.
The `UrlBuilder` object will now generate a warning when users attempt to initialize it by passing in multiple domains in the form of an array.