### PR TITLE
fix: remove deprecated domain sharding functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,32 +56,6 @@ Debug.Print(builder.BuildUrl("gaiman.jpg", parameters));
 // https://domain.imgix.net/gaiman.jpg?w=500&h=1000&s=fc4afbc39b6741560717142aeada876c
 ```
 
-## Domain Sharded URLs
-**Warning: Domain Sharding has been deprecated and will be removed in the next major release**<br>
-To find out more, see our [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding) explaining the decision to remove this feature.
-
-Domain sharding enables you to spread image requests across multiple domains. This allows you to bypass the requests-per-host limits of browsers. We recommend 2-3 domain shards maximum if you are going to use domain sharding.
-
-In order to use domain sharding, you need to add multiple domains to your source. You then provide an array of these domains to a builder.
-
-```csharp
-using Imgix;
-...
-var domains = new [] { "demos-1.imgix.net", "demos-2.imgix.net", "demos-3.imgix.net" };
-var builder = new UrlBuilder(domains);
-var parameters = new Dictionary<String, String>();
-parameters["w"] = "100";
-parameters["h"] = "100";
-Debug.Print(builder.BuildUrl("bridge.png", parameters));
-Debug.Print(builder.BuildUrl("flower.png", parameters));
-
-// Prints out:
-// http://demos-1.imgix.net/bridge.png?h=100&w=100
-// http://demos-2.imgix.net/flower.png?h=100&w=100
-```
-
-By default, shards are calculated using a checksum so that the image path always resolves to the same domain. This improves caching in the browser.
-
 ## What is the `ixlib` param on every request?
 
 For security and diagnostic purposes, we sign all requests with the language and version of library used to generate the URL.

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -9,46 +9,23 @@ namespace Imgix
 {
     public class UrlBuilder
     {
-        public enum ShardStrategyType
-        {
-            CRC,
-            CYCLE
-        }
-
         public Boolean UseHttps;
         public Boolean IncludeLibraryParam;
-        public ShardStrategyType? ShardStrategy;
 
         private String _signKey;
         public String SignKey { set { _signKey = value; } }
 
-        private String[] Domains;
-
-        private int ShardCycleIndex = 0;
-
-        [Obsolete("Warning: Domain sharding has been deprecated and will be removed in the next major version.")]
-        public UrlBuilder(String[] domains,
-                          String signKey = null,
-                          ShardStrategyType shardStrategy = ShardStrategyType.CRC,
-                          Boolean includeLibraryParam = true,
-                          Boolean useHttps = true)
-        {
-            Domains = (String []) domains.Clone();
-            _signKey = signKey;
-            ShardStrategy = shardStrategy;
-            IncludeLibraryParam = includeLibraryParam;
-            UseHttps = useHttps;
-        }
+        private String Domain;
 
         public UrlBuilder(String domain,
                           String signKey = null,
                           Boolean includeLibraryParam = true,
                           Boolean useHttps = true)
-            : this(new[] { domain },
-                   signKey: signKey,
-                   useHttps: useHttps,
-                   includeLibraryParam: includeLibraryParam)
         {
+            Domain = domain;
+            _signKey = signKey;
+            IncludeLibraryParam = includeLibraryParam;
+            UseHttps = useHttps;
         }
 
         public UrlBuilder(String domain, Boolean useHttps)
@@ -56,23 +33,10 @@ namespace Imgix
         {
         }
 
-        [Obsolete("Warning: Domain sharding has been deprecated and will be removed in the next major version.")]
-        public UrlBuilder(String[] domains, Boolean useHttps)
-            : this(domains, signKey: null, useHttps: useHttps)
-        {
-        }
-
         public UrlBuilder(String domain, String signKey, Boolean useHttps)
             : this(domain, signKey: signKey, includeLibraryParam: true, useHttps: useHttps)
         {
         }
-
-        [Obsolete("Warning: Domain sharding has been deprecated and will be removed in the next major version.")]
-        public UrlBuilder(String[] domains, String signKey, Boolean useHttps)
-            : this(domains, signKey: signKey, includeLibraryParam: true, useHttps: useHttps)
-        {
-        }
-
 
         public String BuildUrl(String path)
         {
@@ -87,27 +51,12 @@ namespace Imgix
                 path = WebUtility.UrlEncode(path);
             }
 
-            int index = 0;
-
-            if (ShardStrategy == ShardStrategyType.CRC)
-            {
-                var c = new Crc32();
-                index = (int) (c.ComputeCrcHash(path) % Domains.Length);
-            }
-
-            else if (ShardStrategy == ShardStrategyType.CYCLE)
-            {
-                index = (ShardCycleIndex++)%Domains.Length;
-            }
-
-            var domain = Domains[index];
-
             if (IncludeLibraryParam)
             {
                 parameters.Add("ixlib", String.Format("csharp-{0}", typeof(UrlBuilder).GetTypeInfo().Assembly.GetName().Version));
             }
 
-            return GenerateUrl(domain, path, parameters);
+            return GenerateUrl(Domain, path, parameters);
         }
 
 

--- a/tests/Imgix.Tests/UrlBuilderTest.cs
+++ b/tests/Imgix.Tests/UrlBuilderTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using Imgix;
 using NUnit.Framework;
 
 namespace Imgix.Tests
@@ -53,40 +50,6 @@ namespace Imgix.Tests
         }
 
         [Test]
-        public void UrlBuilderUsesCRCShardingBydefault()
-        {
-            var domains = new [] { "domain1.imgix.net",  "domain2.imgix.net" };
-            var test = new UrlBuilder(domains, includeLibraryParam: false);
-
-            Assert.True(test.BuildUrl("/users/1.png").Contains(domains[0]));
-            Assert.True(test.BuildUrl("/users/1.png").Contains(domains[0]));
-            Assert.True(test.BuildUrl("/users/2.png").Contains(domains[0]));
-            Assert.True(test.BuildUrl("/users/2.png").Contains(domains[0]));
-            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
-            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
-            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
-            Assert.True(test.BuildUrl("/users/a.png").Contains(domains[1]));
-        }
-
-        [Test]
-        public void UrlBuilderClonesDomainList()
-        {
-            var domains = new[] { "domain1.imgix.net", "domain2.imgix.net" };
-            var test = new UrlBuilder(domains, includeLibraryParam: false);
-            domains[0] = "domain3.imgix.net";
-            domains[1] = "domain4.imgix.net";
-
-            Assert.False(test.BuildUrl("/users/1.png").Contains(domains[0]));
-            Assert.False(test.BuildUrl("/users/1.png").Contains(domains[0]));
-            Assert.False(test.BuildUrl("/users/2.png").Contains(domains[0]));
-            Assert.False(test.BuildUrl("/users/2.png").Contains(domains[0]));
-            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
-            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
-            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
-            Assert.False(test.BuildUrl("/users/a.png").Contains(domains[1]));
-        }
-
-        [Test]
         public void UrlBuilderSignsParameterlessRequests()
         {
             var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, includeLibraryParam: false);
@@ -112,47 +75,6 @@ namespace Imgix.Tests
             var test = new UrlBuilder("domain.imgix.net", signKey: SignKey, includeLibraryParam: false);
 
             Assert.AreEqual(test.BuildUrl("test/gaiman.jpg"), "https://domain.imgix.net/test/gaiman.jpg?s=51033c27726f19c0f8229a1ed2dc8523");
-        }
-
-        [Test]
-        public void UrlBuilderWithMultipleDomainsPicksTheFirstWhenShardTypeNull()
-        {
-            var domains = new[] { "domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net" };
-
-            var test = new UrlBuilder(domains, includeLibraryParam: false)
-            {
-                ShardStrategy = null
-            };
-
-            Assert.AreEqual(test.BuildUrl("/users/1.png"), "https://domain.imgix.net/users/1.png");
-            Assert.AreEqual(test.BuildUrl("/users/2.png"), "https://domain.imgix.net/users/2.png");
-            Assert.AreEqual(test.BuildUrl("/users/a.png"), "https://domain.imgix.net/users/a.png");
-        }
-
-        [Test]
-        public void UrlBuilderWithMultipleDomainCyclesThroughDomains()
-        {
-            var domains = new[] {"domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net"};
-
-            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CYCLE, includeLibraryParam: false);
-
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain2.imgix.net/gaiman.jpg");
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain3.imgix.net/gaiman.jpg");
-            Assert.AreEqual(test.BuildUrl("gaiman.jpg"), "https://domain.imgix.net/gaiman.jpg");
-        }
-
-        [Test]
-        public void UrlBuilderWithMultipleDomainsSelectsServerByCRC()
-        {
-            var domains = new[] { "domain.imgix.net", "domain2.imgix.net", "domain3.imgix.net" };
-            var crcs = new [] { "test1.png", "test2.png", "test3.png" }.Select(i => Convert.ToInt32(new Crc32().ComputeCrcHash(i) % domains.Length)).ToArray();
-
-            var test = new UrlBuilder(domains, shardStrategy: UrlBuilder.ShardStrategyType.CRC, includeLibraryParam: false);
-
-            Assert.AreEqual(test.BuildUrl("test1.png"), String.Format("https://{0}/test1.png", domains[crcs[0]]));
-            Assert.AreEqual(test.BuildUrl("test2.png"), String.Format("https://{0}/test2.png", domains[crcs[1]]));
-            Assert.AreEqual(test.BuildUrl("test3.png"), String.Format("https://{0}/test3.png", domains[crcs[2]]));
         }
 
         [Test]
@@ -193,34 +115,6 @@ namespace Imgix.Tests
         {
             var test = new UrlBuilder("demo.imgix.net", includeLibraryParam: true);
             Assert.AreEqual(String.Format("https://demo.imgix.net/demo.png?ixlib=csharp-{0}", typeof(UrlBuilder).Assembly.GetName().Version), test.BuildUrl("demo.png"));
-        }
-
-        [Test]
-        public void UrlBuilderObsoleteConstructor1()
-        {
-            Type[] constructorParameters = new Type[] { typeof(String[]), typeof(String), typeof(UrlBuilder.ShardStrategyType),
-                                                        typeof(Boolean), typeof(Boolean) };
-            Assert.IsTrue(ConstructorHasObsoleteAttribute(constructorParameters));
-        }
-
-        [Test]
-        public void UrlBuilderObsoleteConstructor2()
-        {
-            Type[] constructorParameters = new Type[] { typeof(String[]), typeof(Boolean) };
-            Assert.IsTrue(ConstructorHasObsoleteAttribute(constructorParameters));
-        }
-
-        [Test]
-        public void UrlBuilderObsoleteConstructor3()
-        {
-            Type[] constructorParameters = new Type[] { typeof(String[]), typeof(String), typeof(Boolean) };
-            Assert.IsTrue(ConstructorHasObsoleteAttribute(constructorParameters));
-        }
-
-        private Boolean ConstructorHasObsoleteAttribute(Type[] constructorParameters)
-        {
-            ConstructorInfo ci = typeof(UrlBuilder).GetConstructor(constructorParameters);
-            return ci.GetCustomAttribute(typeof(ObsoleteAttribute)) != null;
         }
     }
 }


### PR DESCRIPTION
This PR removes all domain sharding related fields and methods, following its deprecation in #23 