### PR TITLE
feat: add srcset generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,51 @@ using Imgix;
 var builder = new UrlBuilder("domain.imgix.net", includeLibraryParam: false);
 ```
 
+Srcset Generation
+-----------
+
+The imgix-csharp library allows for generation of custom `srcset` attributes, which can be invoked through `BuildSrcSet()`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.
+
+```csharp
+var builder = new UrlBuilder("domain.imgix.net", "my-token", false, true);
+String srcset = ub.BuildSrcSet("bridge.png");
+Debug.Print(srcset);
+```
+
+Will produce the following attribute value, which can then be served to the client:
+
+```html
+https://domain.imgix.net/bridge.png?w=100&s=494158d968e94ac8e83772ada9a83ad1 100w,
+https://domain.imgix.net/bridge.png?w=116&s=6a22236e189b6a9548b531330647ffa7 116w,
+https://domain.imgix.net/bridge.png?w=134&s=cbf91f556dd67c0b9e26cb9784a83794 134w,
+                                    ...
+https://domain.imgix.net/bridge.png?w=7400&s=503e3ba04588f1c301863c9a5d84fe91 7400w,
+https://domain.imgix.net/bridge.png?w=8192&s=152551ce4ec155f7a03f60f762a1ca33 8192w
+```
+
+In cases where enough information is provided about an image's dimensions, `BuildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w` (width), `h` (height), and `ar` (aspect ratio). By invoking `BuildSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
+
+```csharp
+var builder = new UrlBuilder("domain.imgix.net", "my-token", false, true);
+var parameters = new Dictionary<String, String>();
+parameters["h"] = "200";
+parameters["ar"] = "3:2";
+parameters["fit"] = "crop";
+String srcset = ub.BuildSrcSet("bridge.png", parameters);
+Debug.Print(srcset);
+```
+
+Will produce the following attribute value:
+
+```html
+https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=1&fit=crop&h=200&s=4c79373f535df7e2594a8f6622ec6631 1x,
+https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=2&fit=crop&h=200&s=dc818ae4522494f2f750651304a4d825 2x,
+https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=3&fit=crop&h=200&s=ba1ec0cef6c77ff02330d40cc4dae932 3x,
+https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=4&fit=crop&h=200&s=b51e497d9461be62354c0ea12b6524fb 4x,
+https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=5&fit=crop&h=200&s=dc37c1fbee505d425ca8e3764b37f791 5x
+```
+
+For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
+
 ## Code of Conduct
 Users contributing to or participating in the development of this project are subject to the terms of imgix's [Code of Conduct](https://github.com/imgix/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The imgix-csharp library allows for generation of custom `srcset` attributes, wh
 
 ```csharp
 var builder = new UrlBuilder("domain.imgix.net", "my-token", false, true);
-String srcset = ub.BuildSrcSet("bridge.png");
+String srcset = builder.BuildSrcSet("bridge.png");
 Debug.Print(srcset);
 ```
 
@@ -85,7 +85,7 @@ Will produce the following attribute value, which can then be served to the clie
 https://domain.imgix.net/bridge.png?w=100&s=494158d968e94ac8e83772ada9a83ad1 100w,
 https://domain.imgix.net/bridge.png?w=116&s=6a22236e189b6a9548b531330647ffa7 116w,
 https://domain.imgix.net/bridge.png?w=134&s=cbf91f556dd67c0b9e26cb9784a83794 134w,
-                                    ...
+                                            ...
 https://domain.imgix.net/bridge.png?w=7400&s=503e3ba04588f1c301863c9a5d84fe91 7400w,
 https://domain.imgix.net/bridge.png?w=8192&s=152551ce4ec155f7a03f60f762a1ca33 8192w
 ```
@@ -98,18 +98,18 @@ var parameters = new Dictionary<String, String>();
 parameters["h"] = "200";
 parameters["ar"] = "3:2";
 parameters["fit"] = "crop";
-String srcset = ub.BuildSrcSet("bridge.png", parameters);
-Debug.Print(srcset);
+String srcset = builder.BuildSrcSet("bridge.png", parameters);
+Console.WriteLine(srcset);
 ```
 
 Will produce the following attribute value:
 
 ```html
-https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=1&fit=crop&h=200&s=4c79373f535df7e2594a8f6622ec6631 1x,
-https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=2&fit=crop&h=200&s=dc818ae4522494f2f750651304a4d825 2x,
-https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=3&fit=crop&h=200&s=ba1ec0cef6c77ff02330d40cc4dae932 3x,
-https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=4&fit=crop&h=200&s=b51e497d9461be62354c0ea12b6524fb 4x,
-https://domain.imgix.net/bridge.png?ar=3%3A2&dpr=5&fit=crop&h=200&s=dc37c1fbee505d425ca8e3764b37f791 5x
+https://domain.imgix.net/bridge.png?h=200&ar=3%3A2&fit=crop&dpr=1&s=f39a78a6a2f245a70ba6aac910088435 1x,
+https://domain.imgix.net/bridge.png?h=200&ar=3%3A2&fit=crop&dpr=2&s=d5dfd75bd777283d82975ab18a3091ff 2x,
+https://domain.imgix.net/bridge.png?h=200&ar=3%3A2&fit=crop&dpr=3&s=8f25811130e3573530754c52f86a851d 3x,
+https://domain.imgix.net/bridge.png?h=200&ar=3%3A2&fit=crop&dpr=4&s=ec348479a843a688c2ef9be487ea9be8 4x,
+https://domain.imgix.net/bridge.png?h=200&ar=3%3A2&fit=crop&dpr=5&s=ce70bbfd682e683497f1afa6118ae2e3 5x
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -107,6 +108,22 @@ namespace Imgix
                         return String.Format("{0}={1}", encodedKey, encodedVal);
                     }
                 ));
+        }
+
+        private List<int> targetWidths() {
+            List<int> resolutions = new List<int>();
+            int MAX_SIZE = 8192, roundedPrev;
+            double SRCSET_INCREMENT_PERCENTAGE = 8;
+            double prev = 100;
+
+            while (prev <= MAX_SIZE)
+            {
+                resolutions.Add((int)(2 * Math.Round(prev / 2)));
+                prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100) * 2;
+            }
+            resolutions.Add(MAX_SIZE);
+
+            return resolutions;
         }
     }
 }

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -14,9 +14,9 @@ namespace Imgix
 
         private String _signKey;
         public String SignKey { set { _signKey = value; } }
-
         private String Domain;
-        //private const List<int> SRCSET_TARGET_WIDTHS = GenerateTargetWidths();
+
+        private static readonly List<int> SRCSET_TARGET_WIDTHS = GenerateTargetWidths();
 
         public UrlBuilder(String domain,
                           String signKey = null,
@@ -119,7 +119,6 @@ namespace Imgix
         private String GenerateSrcSetPairs(String domain, String path, Dictionary<String, String> parameters)
         {
             String srcset = "";
-            List<int> SRCSET_TARGET_WIDTHS = GenerateTargetWidths();
 
             foreach(int width in SRCSET_TARGET_WIDTHS)
             {
@@ -131,7 +130,7 @@ namespace Imgix
             return srcset.Substring(0, srcset.Length - 2);
         }
 
-        private List<int> GenerateTargetWidths()
+        private static List<int> GenerateTargetWidths()
         {
             List<int> resolutions = new List<int>();
             int MAX_SIZE = 8192, roundedPrev;

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -108,8 +108,9 @@ namespace Imgix
 
             foreach(int ratio in targetRatios)
             {
-                parameters.Add("dpr", ratio.ToString());
-                srcset += BuildUrl(path, parameters) + " " + "x,\n";
+                parameters["dpr"] = ratio.ToString();
+                parameters.Remove("ixlib");
+                srcset += BuildUrl(path, parameters) + " " + ratio.ToString()+ "x,\n";
             }
 
             return srcset.Substring(0, srcset.Length - 2);
@@ -122,7 +123,8 @@ namespace Imgix
 
             foreach(int width in SRCSET_TARGET_WIDTHS)
             {
-                parameters.Add("w", width.ToString());
+                parameters["w"] = width.ToString();
+                parameters.Remove("ixlib");
                 srcset += BuildUrl(path, parameters) + " " + width + "w,\n";
             }
 

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -1,13 +1,554 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using Imgix;
+
 namespace Imgix.Tests
 {
-    [TestFixture()]
+    [TestFixture][SetUpFixture]
     public class SrcSetTest
     {
-        [Test()]
-        public void TestCase()
+        private static Dictionary<String, String> parameters;
+        private static String[] srcsetSplit;
+        private static String[] srcsetWidthSplit;
+        private static String[] srcsetHeightSplit;
+        private static String[] srcsetAspectRatioSplit;
+        private static String[] srcsetWidthAndHeightSplit;
+        private static String[] srcsetWidthAndAspectRatioSplit;
+        private static String[] srcsetHeightAndAspectRatioSplit;
+
+        [TestFixtureSetUp]
+        public void BuildAllSrcSets()
         {
+            String srcset, srcsetWidth, srcsetHeight, srcsetAspectRatio, srcsetWidthAndHeight, srcsetWidthAndAspectRatio, srcsetHeightAndAspectRatio;
+
+            UrlBuilder ub = new UrlBuilder("test.imgix.net", "MYT0KEN", true, true);
+            parameters = new Dictionary<String, String>();
+
+            srcset = ub.BuildSrcSet("image.jpg");
+            srcsetSplit = srcset.Split(',');
+
+            parameters.Add("w", "300");
+            srcsetWidth = ub.BuildSrcSet("image.jpg");
+            srcsetWidthSplit = srcsetWidth.Split(',');
+            parameters.Clear();
+
+            parameters.Add("h", "300");
+            srcsetHeight = ub.BuildSrcSet("image.jpg");
+            srcsetHeightSplit = srcsetHeight.Split(',');
+            parameters.Clear();
+
+            parameters.Add("ar", "3:2");
+            srcsetAspectRatio = ub.BuildSrcSet("image.jpg");
+            srcsetAspectRatioSplit = srcsetAspectRatio.Split(',');
+            parameters.Clear();
+
+            parameters.Add("w", "300");
+            parameters.Add("h", "400");
+            srcsetWidthAndHeight = ub.BuildSrcSet("image.jpg");
+            srcsetWidthAndHeightSplit = srcsetWidthAndHeight.Split(',');
+            parameters.Clear();
+
+            parameters.Add("w", "300");
+            parameters.Add("ar", "3:2");
+            srcsetWidthAndAspectRatio = ub.BuildSrcSet("image.jpg");
+            srcsetWidthAndAspectRatioSplit = srcsetWidthAndAspectRatio.Split(',');
+            parameters.Clear();
+
+            parameters.Add("h", "300");
+            parameters.Add("ar", "3:2");
+            srcsetHeightAndAspectRatio = ub.BuildSrcSet("image.jpg");
+            srcsetHeightAndAspectRatioSplit = srcsetHeightAndAspectRatio.Split(',');
+            parameters.Clear();
+        }
+
+        [Test]
+        public void NoParametersGeneratesCorrectWidths()
+        {
+            int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+
+            String generatedWidth;
+            int index = 0;
+            int widthInt;
+
+            foreach (String src in srcsetSplit)
+            {
+                generatedWidth = src.Split(' ')[1];
+                widthInt = int.Parse(generatedWidth.Substring(0, generatedWidth.Length - 1));
+                Assert.AreEqual(targetWidths[index], widthInt);
+                index++;
+            }
+        }
+
+        [Test]
+        public void NoParametersReturnsExpectedNumberOfPairs()
+        {
+            int expectedPairs = 31;
+            Assert.AreEqual(expectedPairs, srcsetSplit.Length);
+        }
+
+        [Test]
+        public void NoParametersDoesNotExceedBounds()
+        {
+            String minWidth = srcsetSplit[0].Split(' ')[1];
+            String maxWidth = srcsetSplit[srcsetSplit.Length - 1].Split(' ')[1];
+
+            int minWidthInt = int.Parse(minWidth.Substring(0, minWidth.Length - 1));
+            int maxWidthInt = int.Parse(maxWidth.Substring(0, maxWidth.Length - 1));
+
+            Assert.True(minWidthInt >= 100);
+            Assert.True(maxWidthInt <= 8192);
+        }
+
+        // a 17% testing threshold is used to account for rounding
+        [Test]
+        public void NoParametersDoesNotIncreaseMoreThan17Percent()
+        {
+            const double INCREMENT_ALLOWED = .17;
+            String width;
+            int widthInt, prev;
+
+            // convert and store first width (typically: 100)
+            width = srcsetSplit[0].Split(' ')[1];
+            prev = int.Parse(width.Substring(0, width.Length - 1));
+
+            foreach (String src in srcsetSplit)
+            {
+                width = src.Split(' ')[1];
+                widthInt = int.Parse(width.Substring(0, width.Length - 1));
+
+                Assert.True((widthInt / prev) < (1 + INCREMENT_ALLOWED));
+                prev = widthInt;
+            }
+        }
+
+        [Test]
+        public void NoParametersSignsUrls()
+        {
+            String src, parameters, generatedSignature, signatureBase;
+            var expectedSignature = new uint();
+
+            foreach (String srcLine in srcsetSplit)
+            {
+
+                src = srcLine.Split(' ')[0];
+                Assert.True(src.Contains("s="));
+                generatedSignature = src.Substring(src.IndexOf("s=") + 2);
+
+                parameters = src.Substring(src.IndexOf("?"), src.IndexOf("s=") - 1);
+                signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+                // create MD5 hash
+                var crc = new Crc32();
+                expectedSignature = crc.ComputeCrcHash(signatureBase);
+
+                Assert.AreEqual(expectedSignature, generatedSignature);
+            }
+        }
+
+        [Test]
+        public void WidthInDPRForm()
+        {
+            String generatedRatio;
+            int expectedRatio = 1;
+            Assert.True(srcsetWidthSplit.Length == 5);
+
+            foreach (String src in srcsetWidthSplit)
+            {
+                generatedRatio = src.Split(' ')[1];
+                Assert.AreEqual(expectedRatio + "x", generatedRatio);
+                expectedRatio++;
+            }
+        }
+
+        [Test]
+        public void WidthSignsUrls()
+        {
+            String src, parameters, generatedSignature, signatureBase;
+            var expectedSignature = new uint();
+
+            foreach (String srcLine in srcsetWidthSplit)
+            {
+
+                src = srcLine.Split(' ')[0];
+                Assert.True(src.Contains("s="));
+                generatedSignature = src.Substring(src.IndexOf("s=") + 2);
+
+                parameters = src.Substring(src.IndexOf("?"), src.IndexOf("s=") - 1);
+                signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+                // create MD5 hash
+                var crc = new Crc32();
+                expectedSignature = crc.ComputeCrcHash(signatureBase);
+
+                Assert.AreEqual(expectedSignature, generatedSignature);
+            }
+        }
+
+        [Test]
+        public void WidthIncludesDPRParam()
+        {
+            String src;
+
+            for (int i = 0; i < srcsetWidthSplit.Length; i++)
+            {
+                src = srcsetWidthSplit[i].Split(' ')[0];
+                Assert.True(src.Contains(String.Format("dpr=%s", i + 1)));
+            }
+        }
+
+        [Test]
+        public void HeightGeneratesCorrectWidths()
+        {
+            int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+
+            String generatedWidth;
+            int index = 0;
+            int widthInt;
+
+            foreach (String src in srcsetHeightSplit)
+            {
+                generatedWidth = src.Split(' ')[1];
+                widthInt = int.Parse(generatedWidth.Substring(0, generatedWidth.Length - 1));
+                Assert.AreEqual(targetWidths[index], widthInt);
+                index++;
+            }
+        }
+
+        [Test]
+        public void HeightContainsHeightParameter()
+        {
+            String url;
+
+            foreach (String src in srcsetHeightSplit)
+            {
+                url = src.Split(' ')[0];
+                Assert.True(url.Contains("h="));
+            }
+        }
+
+        [Test]
+        public void HeightReturnsExpectedNumberOfPairs()
+        {
+            int expectedPairs = 31;
+            Assert.AreEqual(expectedPairs, srcsetHeightSplit.Length);
+        }
+
+        [Test]
+        public void HeightDoesNotExceedBounds()
+        {
+            String minWidth = srcsetHeightSplit[0].Split(' ')[1];
+            String maxWidth = srcsetHeightSplit[srcsetHeightSplit.Length - 1].Split(' ')[1];
+
+            int minWidthInt = int.Parse(minWidth.Substring(0, minWidth.Length - 1));
+            int maxWidthInt = int.Parse(maxWidth.Substring(0, maxWidth.Length - 1));
+
+            Assert.True(minWidthInt >= 100);
+            Assert.True(maxWidthInt <= 8192);
+        }
+
+        // a 17% testing threshold is used to account for rounding
+        [Test]
+        public void testHeightDoesNotIncreaseMoreThan17Percent()
+        {
+            const double INCREMENT_ALLOWED = .17;
+            String width;
+            int widthInt, prev;
+
+            // convert and store first width (typically: 100)
+            width = srcsetHeightSplit[0].Split(' ')[1];
+            prev = int.Parse(width.Substring(0, width.Length - 1));
+
+            foreach (String src in srcsetHeightSplit)
+            {
+                width = src.Split(' ')[1];
+                widthInt = int.Parse(width.Substring(0, width.Length - 1));
+
+                Assert.True((widthInt / prev) < (1 + INCREMENT_ALLOWED));
+                prev = widthInt;
+            }
+        }
+
+        [Test]
+        public void testHeightSignsUrls()
+        {
+            String src, parameters, generatedSignature, signatureBase;
+            var expectedSignature = new uint();
+
+            foreach (String srcLine in srcsetHeightSplit)
+            {
+
+                src = srcLine.Split(' ')[0];
+                Assert.True(src.Contains("s="));
+                generatedSignature = src.Substring(src.IndexOf("s=") + 2);
+
+                parameters = src.Substring(src.IndexOf("?"), src.IndexOf("s=") - 1);
+                signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+                // create MD5 hash
+                var crc = new Crc32();
+                expectedSignature = crc.ComputeCrcHash(signatureBase);
+
+                Assert.AreEqual(expectedSignature, generatedSignature);
+            }
+        }
+
+        [Test]
+        public void WidthAndHeightInDPRForm()
+        {
+            String generatedRatio;
+            int expectedRatio = 1;
+            Assert.True(srcsetWidthAndHeightSplit.Length == 5);
+
+            foreach (String src in srcsetWidthAndHeightSplit)
+            {
+                generatedRatio = src.Split(' ')[1];
+                Assert.AreEqual(expectedRatio + "x", generatedRatio);
+                expectedRatio++;
+            }
+        }
+
+        [Test]
+        public void WidthAndHeightSignsUrls()
+        {
+            String src, parameters, generatedSignature, signatureBase;
+            var expectedSignature = new uint();
+
+            foreach (String srcLine in srcsetWidthAndHeightSplit)
+            {
+
+                src = srcLine.Split(' ')[0];
+                Assert.True(src.Contains("s="));
+                generatedSignature = src.Substring(src.IndexOf("s=") + 2);
+
+                parameters = src.Substring(src.IndexOf("?"), src.IndexOf("s=") - 1);
+                signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+                // create MD5 hash
+                var crc = new Crc32();
+                expectedSignature = crc.ComputeCrcHash(signatureBase);
+
+                Assert.AreEqual(expectedSignature, generatedSignature);
+            }
+        }
+
+        [Test]
+        public void WidthAndHeightIncludesDPRParam()
+        {
+            String src;
+
+            for (int i = 0; i < srcsetWidthAndHeightSplit.Length; i++)
+            {
+                src = srcsetWidthAndHeightSplit[i].Split(' ')[0];
+                Assert.True(src.Contains(String.Format("dpr=%s", i + 1)));
+            }
+        }
+
+        [Test]
+        public void AspectRatioGeneratesCorrectWidths()
+        {
+            int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+
+            String generatedWidth;
+            int index = 0;
+            int widthInt;
+
+            foreach (String src in srcsetAspectRatioSplit)
+            {
+                generatedWidth = src.Split(' ')[1];
+                widthInt = int.Parse(generatedWidth.Substring(0, generatedWidth.Length - 1));
+                Assert.AreEqual(targetWidths[index], widthInt);
+                index++;
+            }
+        }
+
+        [Test]
+        public void AspectRatioContainsARParameter()
+        {
+            String url;
+
+            foreach (String src in srcsetAspectRatioSplit)
+            {
+                url = src.Split(' ')[0];
+                Assert.True(url.Contains("h="));
+            }
+        }
+
+        [Test]
+        public void AspectRatioReturnsExpectedNumberOfPairs()
+        {
+            int expectedPairs = 31;
+            Assert.AreEqual(expectedPairs, srcsetAspectRatioSplit.Length);
+        }
+
+        [Test]
+        public void AspectRatioDoesNotExceedBounds()
+        {
+            String minWidth = srcsetAspectRatioSplit[0].Split(' ')[1];
+            String maxWidth = srcsetAspectRatioSplit[srcsetAspectRatioSplit.Length - 1].Split(' ')[1];
+
+            int minWidthInt = int.Parse(minWidth.Substring(0, minWidth.Length - 1));
+            int maxWidthInt = int.Parse(maxWidth.Substring(0, maxWidth.Length - 1));
+
+            Assert.True(minWidthInt >= 100);
+            Assert.True(maxWidthInt <= 8192);
+        }
+
+        // a 17% testing threshold is used to account for rounding
+        [Test]
+        public void AspectRatioDoesNotIncreaseMoreThan17Percent()
+        {
+            const double INCREMENT_ALLOWED = .17;
+            String width;
+            int widthInt, prev;
+
+            // convert and store first width (typically: 100)
+            width = srcsetAspectRatioSplit[0].Split(' ')[1];
+            prev = int.Parse(width.Substring(0, width.Length - 1));
+
+            foreach (String src in srcsetAspectRatioSplit)
+            {
+                width = src.Split(' ')[1];
+                widthInt = int.Parse(width.Substring(0, width.Length - 1));
+
+                Assert.True((widthInt / prev) < (1 + INCREMENT_ALLOWED));
+                prev = widthInt;
+            }
+        }
+
+        [Test]
+        public void AspectRatioSignsUrls()
+        {
+            String src, parameters, generatedSignature, signatureBase;
+            var expectedSignature = new uint();
+
+            foreach (String srcLine in srcsetAspectRatioSplit)
+            {
+
+                src = srcLine.Split(' ')[0];
+                Assert.True(src.Contains("s="));
+                generatedSignature = src.Substring(src.IndexOf("s=") + 2);
+
+                parameters = src.Substring(src.IndexOf("?"), src.IndexOf("s=") - 1);
+                signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+                // create MD5 hash
+                var crc = new Crc32();
+                expectedSignature = crc.ComputeCrcHash(signatureBase);
+
+                Assert.AreEqual(expectedSignature, generatedSignature);
+            }
+        }
+
+        [Test]
+        public void WidthAndAspectRatioInDPRForm()
+        {
+            String generatedRatio;
+            int expectedRatio = 1;
+            Assert.True(srcsetWidthAndAspectRatioSplit.Length == 5);
+
+            foreach (String src in srcsetWidthAndAspectRatioSplit)
+            {
+                generatedRatio = src.Split(' ')[1];
+                Assert.AreEqual(expectedRatio + "x", generatedRatio);
+                expectedRatio++;
+            }
+        }
+
+        [Test]
+        public void WidthAndAspectRatioSignsUrls()
+        {
+            String src, parameters, generatedSignature, signatureBase;
+            var expectedSignature = new uint();
+
+            foreach (String srcLine in srcsetWidthAndAspectRatioSplit)
+            {
+
+                src = srcLine.Split(' ')[0];
+                Assert.True(src.Contains("s="));
+                generatedSignature = src.Substring(src.IndexOf("s=") + 2);
+
+                parameters = src.Substring(src.IndexOf("?"), src.IndexOf("s=") - 1);
+                signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+                // create MD5 hash
+                var crc = new Crc32();
+                expectedSignature = crc.ComputeCrcHash(signatureBase);
+
+                Assert.AreEqual(expectedSignature, generatedSignature);
+            }
+        }
+
+        [Test]
+        public void WidthAndAspectRatioIncludesDPRParam()
+        {
+            String src;
+
+            for (int i = 0; i < srcsetWidthAndAspectRatioSplit.Length; i++)
+            {
+                src = srcsetWidthAndAspectRatioSplit[i].Split(' ')[0];
+                Assert.True(src.Contains(String.Format("dpr=%s", i + 1)));
+            }
+        }
+
+        [Test]
+        public void HeightAndAspectRatioInDPRForm()
+        {
+            String generatedRatio;
+            int expectedRatio = 1;
+            Assert.True(srcsetHeightAndAspectRatioSplit.Length == 5);
+
+            foreach (String src in srcsetHeightAndAspectRatioSplit)
+            {
+                generatedRatio = src.Split(' ')[1];
+                Assert.AreEqual(expectedRatio + "x", generatedRatio);
+                expectedRatio++;
+            }
+        }
+
+        [Test]
+        public void HeightAndAspectRatioSignsUrls()
+        {
+            String src, parameters, generatedSignature, signatureBase;
+            var expectedSignature = new uint();
+
+            foreach (String srcLine in srcsetHeightAndAspectRatioSplit)
+            {
+
+                src = srcLine.Split(' ')[0];
+                Assert.True(src.Contains("s="));
+                generatedSignature = src.Substring(src.IndexOf("s=") + 2);
+
+                parameters = src.Substring(src.IndexOf("?"), src.IndexOf("s=") - 1);
+                signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+                // create MD5 hash
+                var crc = new Crc32();
+                expectedSignature = crc.ComputeCrcHash(signatureBase);
+
+                Assert.AreEqual(expectedSignature, generatedSignature);
+            }
+        }
+
+        [Test]
+        public void HeightAndAspectRatioIncludesDPRParam()
+        {
+            String src;
+
+            for (int i = 0; i < srcsetHeightAndAspectRatioSplit.Length; i++)
+            {
+                src = srcsetHeightAndAspectRatioSplit[i].Split(' ')[0];
+                Assert.True(src.Contains(String.Format("dpr=%s", i + 1)));
+            }
         }
     }
 }

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -1,0 +1,13 @@
+﻿using NUnit.Framework;
+using System;
+namespace Imgix.Tests
+{
+    [TestFixture()]
+    public class SrcSetTest
+    {
+        [Test()]
+        public void TestCase()
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a new class method in `UrlBuilder` that will generate a `srcset` string, which can be used in the `srcset` attribute on an `<img>` HTML element. `BuildSrcSet()` takes a `path` and `params` argument similar to `BuildUrl()`, and will return a `String` in one of two `srcset` formats.

**Srcset Width-Pairs**
The first format creates `srcset` width-pairs, a comma-delimited list of URLs and width descriptors corresponding to each one. This allows for responsive size switching based on the current width of the browser viewport. `BuildSrcSet()` will append any `params` passed to the method to each URL constructed within the list. The following is an example of how to generate a width-pair `srcset`:
```csharp
UrlBuilder builder = new UrlBuilder("test.imgix.net", signKey:"", includeLibraryParam: false, useHttps: true);
Dictionary<String, String> parameters = new Dictionary<string, string>();
parameters["fit"] = "crop";            
parameters["crop"] = "faces";
String srcset = builder.BuildSrcSet("bridge.png", parameters);
Console.WriteLine(srcset);
```
will return the following `String` (collapsed for brevity):
```html
https://test.imgix.net/bridge.png?fit=crop&crop=faces&w=100 100w,
https://test.imgix.net/bridge.png?fit=crop&crop=faces&w=116 116w,
https://test.imgix.net/bridge.png?fit=crop&crop=faces&w=134 134w,
								...
https://test.imgix.net/bridge.png?fit=crop&crop=faces&w=7400 7400w,
https://test.imgix.net/bridge.png?fit=crop&crop=faces&w=8192 8192w
```
Notice that a `w=` parameter is automatically inserted for each entry in the `srcset` list. This is required in order for the element to properly display the correctly-sized image corresponding to the viewport's width.

**Device Pixel Ratio (DPR) Srcset**
The second format this method can return is a `srcset` list of same-size images in varying resolutions. In this case, images are scaled using the `dpr=` parameter to adjust for the [device pixel ratio](https://docs.imgix.com/apis/url/pixel-density/dpr) of the browser. A DPR `srcset` will be automatically generated instead of a width-pair srcset if exact dimensions for the output image are specified, by providing either a `w` (width) **or** a `h` (height) and `ar` (aspect ratio) in the `parametes` argument.
The following is an example of how to generate a DPR `srcset`:
```csharp
UrlBuilder builder = new UrlBuilder("test.imgix.net", signKey:"", includeLibraryParam: false, useHttps: true);
Dictionary<String, String> parameters = new Dictionary<string, string>();
parameters["h"] = "200";
parameters["ar"] = "3:2";   
String srcset = builder.BuildSrcSet("bridge.png", parameters);
Console.WriteLine(srcset);
```
which will return the following `String`:
```html
https://test.imgix.net/bridge.png?h=200&ar=3%3A2&dpr=1 1x,
https://test.imgix.net/bridge.png?h=200&ar=3%3A2&dpr=2 2x,
https://test.imgix.net/bridge.png?h=200&ar=3%3A2&dpr=3 3x,
https://test.imgix.net/bridge.png?h=200&ar=3%3A2&dpr=4 4x,
https://test.imgix.net/bridge.png?h=200&ar=3%3A2&dpr=5 5x
```
---
**Signing URLs**
`BuildSrcSet()` also supports signing URLs, which can be very useful for generating server-side and then passing to the client. This will avoid having to expose your imgix source's secure token to the client.
```csharp
UrlBuilder builder = new UrlBuilder("test.imgix.net", signKey:"my-token", includeLibraryParam: false, useHttps: true);
Dictionary<String, String> parameters = new Dictionary<string, string>();
parameters["w"] = "800";
String srcset = builder.BuildSrcSet("bridge.png", parameters);   
Console.WriteLine(srcset);
```
generates a `srcset` with unique signatures for each URL:
```html
https://test.imgix.net/bridge.png?w=800&dpr=1&s=48ab8bc59b52eaa6145df25139742dde 1x,
https://test.imgix.net/bridge.png?w=800&dpr=2&s=6d9e5473aac1deab62f91d940c5e3f42 2x,
https://test.imgix.net/bridge.png?w=800&dpr=3&s=c37997036878f97a9c42f29548bb6856 3x,
https://test.imgix.net/bridge.png?w=800&dpr=4&s=10606b93fa955a3e310ba5564627b4ea 4x,
https://test.imgix.net/bridge.png?w=800&dpr=5&s=2b7eb1ef729e7a794d857681b51f1c0e 5x
```
---
For more information on `srcset`, building responsive images, and resolution switching:
- [Responsive images - MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
- [Srcset and Sizes - Eric Portis](https://ericportis.com/posts/2014/srcset-sizes/)