### PR TITLE
feat: introduce custom srcsets

### DIFF
--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -28,7 +28,7 @@ namespace Imgix
 
         const int MaxWidth = 8192;
         const int MinWidth = 100;
-        const int SrcSetWidthTolerance = 8;
+        const double SrcSetWidthTolerance = 0.08;
 
         public UrlBuilder(String domain,
                           String signKey = null,
@@ -138,7 +138,7 @@ namespace Imgix
         public String BuildSrcSet(
             String path,
             Dictionary<String, String> parameters,
-            int tol = SrcSetWidthTolerance)
+            double tol = SrcSetWidthTolerance)
         {
             return BuildSrcSet(path, parameters, MinWidth, MaxWidth, tol);
         }
@@ -179,7 +179,7 @@ namespace Imgix
             Dictionary<String, String> parameters,
             int begin = MinWidth,
             int end = MaxWidth,
-            int tol = SrcSetWidthTolerance)
+            double tol = SrcSetWidthTolerance)
         {
             return BuildSrcSet(path, parameters, begin, end, tol, false);
         }
@@ -193,6 +193,7 @@ namespace Imgix
         /// <returns>srcset attribute string</returns>
         public String BuildSrcSet(String path, Dictionary<String, String> parameters, List<int> targets)
         {
+            Validator.ValidateWidths(targets);
             return GenerateSrcSetPairs(path, parameters, targets: targets);
         }
 
@@ -219,7 +220,7 @@ namespace Imgix
             Dictionary<String, String> parameters,
             int begin = MinWidth,
             int end = MaxWidth,
-            int tol = SrcSetWidthTolerance,
+            double tol = SrcSetWidthTolerance,
             Boolean disableVariableQuality = false)
         {
 
@@ -307,8 +308,9 @@ namespace Imgix
             GenerateTargetWidths(
                 int begin = MinWidth,
                 int end = MaxWidth,
-                int tol = SrcSetWidthTolerance)
+                double tol = SrcSetWidthTolerance)
         {
+            Validator.ValidateMinMaxTol(begin, end, tol);
             return ComputeTargetWidths(begin, end, tol);
         }
 
@@ -346,7 +348,7 @@ namespace Imgix
             while (begin < end && begin < MaxWidth)
             {
                 resolutions.Add((int) Math.Round(begin));
-                begin *= 1 + (tol / 100) * 2;
+                begin *= 1 + tol * 2;
             }
 
             if (resolutions.Last() < end)

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -112,7 +112,7 @@ namespace Imgix
         /// <param name="parameters">dictionary of query parameters</param>
         /// <param name="disableVariableQuality">toggle variable quality output on
         /// (default/false) or off (true).</param>
-        /// <returns></returns>
+        /// <returns>srcset attribute string</returns>
         public String BuildSrcSet(
             String path,
             Dictionary<String, String> parameters,
@@ -144,7 +144,7 @@ namespace Imgix
         }
 
         /// <summary>
-        /// Create a a srcset attribute by specifying `begin` and `end`.
+        /// Create a srcset attribute by specifying `begin` and `end`.
         ///
         /// This method creates a srcset attribute string whose image width
         /// values range between `begin` and `end`.
@@ -163,7 +163,7 @@ namespace Imgix
         }
 
         /// <summary>
-        /// Create a a srcset attribute by specifying `begin`, `end`, and `tol`.
+        /// Create a srcset attribute by specifying `begin`, `end`, and `tol`.
         ///
         /// This method creates a srcset attribute string whose image width
         /// values range between `begin` and `end` with the specified amount

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -129,22 +129,30 @@ namespace Imgix
             return srcset.Substring(0, srcset.Length - 2);
         }
 
-        private static List<int> GenerateTargetWidths()
+        public static List<int>
+            GenerateTargetWidths(
+                double start = 100, double stop = 8192, double tol = 8)
         {
             List<int> resolutions = new List<int>();
-            int MAX_SIZE = 8192, roundedPrev;
-            double SRCSET_PERCENT_INCREMENT = 8;
-            double prev = 100;
+            int MAX_SIZE = 8192;
 
-            while (prev < MAX_SIZE)
+            while (start < stop && start < MAX_SIZE)
             {
-                roundedPrev = (int)(2 * Math.Round(prev / 2));
-                resolutions.Add(roundedPrev);
-                prev *= 1 + (SRCSET_PERCENT_INCREMENT / 100) * 2;
+                resolutions.Add(MakeEven(start));
+                start *= 1 + (tol / 100) * 2;
             }
-            resolutions.Add(MAX_SIZE);
+
+            if (resolutions.Last() < stop)
+            {
+                resolutions.Add(MakeEven(stop));
+            }
 
             return resolutions;
+        }
+
+        private static int MakeEven(double value)
+        {
+            return (int)(2 * Math.Round(value / 2));
         }
 
         private String HashString(String input)

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -166,7 +166,6 @@ namespace Imgix
             GenerateTargetWidths(
                 double start = 100, double stop = 8192, double tol = 8)
         {
-            List<int> resolutions = new List<int>();
             int MAX_SIZE = 8192;
 
             if (start == stop)
@@ -174,6 +173,7 @@ namespace Imgix
                 return new List<int> {MakeEven(start)};
             }
 
+            List<int> resolutions = new List<int>();
             while (start < stop && start < MAX_SIZE)
             {
                 resolutions.Add(MakeEven(start));

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -185,6 +185,18 @@ namespace Imgix
         }
 
         /// <summary>
+        /// Create a srcset attribute by specifying a list of target widths.
+        /// </summary>
+        /// <param name="path">path to the image, i.e. "image/file.png"</param>
+        /// <param name="parameters">dictionary of query parameters</param>
+        /// <param name="targets">list of target widths</param>
+        /// <returns>srcset attribute string</returns>
+        public String BuildSrcSet(String path, Dictionary<String, String> parameters, List<int> targets)
+        {
+            return GenerateSrcSetPairs(path, parameters, targets: targets);
+        }
+
+        /// <summary>
         /// Create a srcset attribute.
         ///
         /// If the `parameters` indicate the srcset attribute should be
@@ -201,7 +213,7 @@ namespace Imgix
         /// <param name="tol">tolerable amount of width value variation, 1-100.</param>
         /// <param name="disableVariableQuality">toggle variable quality output on
         /// (default/false) or off (true).</param>
-        /// <returns></returns>
+        /// <returns>srcset attribute string</returns>
         public String BuildSrcSet(
             String path,
             Dictionary<String, String> parameters,

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -16,13 +16,19 @@ namespace Imgix
         public String SignKey { set { _signKey = value; } }
         private String Domain;
 
-        private static readonly List<int> SRCSET_TARGET_WIDTHS = GenerateTargetWidths();
+        private static readonly int[] SrcSetTargetWidths = {
+            100, 116, 135, 156, 181, 210, 244, 283,
+            328, 380, 441, 512, 594, 689, 799, 927,
+            1075, 1247, 1446, 1678, 1946, 2257, 2619,
+            3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192 };
 
-        private static readonly Dictionary<int, int> DPR_QUALITIES = 
-            new Dictionary<int, int>() { 
-                { 1, 75 }, { 2, 50 }, 
-                { 3, 35 }, { 4, 23 }, 
-                { 5, 20 } };
+        private static readonly int[] DprRatios = { 1, 2, 3, 4, 5 };
+        private static readonly int[] DprQualities = { 75, 50, 35, 23, 20 };
+
+
+        const int MaxWidth = 8192;
+        const int MinWidth = 100;
+        const int SrcSetWidthTolerance = 8;
 
         public UrlBuilder(String domain,
                           String signKey = null,
@@ -67,38 +73,6 @@ namespace Imgix
             return GenerateUrl(Domain, path, parameters);
         }
 
-        public String BuildSrcSet(String path)
-        {
-            return BuildSrcSet(path, new Dictionary<string, string>());
-        }
-
-
-        public String BuildSrcSet(
-            String path,
-            Dictionary<String, String> parameters,
-            int start = 100,
-            int stop = 8192,
-            int tol = 8,
-            Boolean disableVariableQuality = false)
-        {
-            String srcset;
-            parameters.TryGetValue("w", out String width);
-            parameters.TryGetValue("h", out String height);
-            parameters.TryGetValue("ar", out String aspectRatio);
-
-            if ((width != null) || (height != null && aspectRatio != null))
-            {
-                srcset = GenerateSrcSetDPR(Domain, path, parameters, disableVariableQuality);
-            }
-            else
-            {
-                List<int> targets = GenerateTargetWidths(start: start, stop: stop, tol: tol);
-                srcset = GenerateSrcSetPairs(Domain, path, parameters, targets: targets);
-            }
-
-            return srcset;
-        }
-
         private String GenerateUrl(String domain, String path, Dictionary<String, String> parameters)
         {
             String scheme = UseHttps ? "https" : "http";
@@ -116,39 +90,172 @@ namespace Imgix
             return String.Format("{0}://{1}/{2}{3}", scheme, domain, path, localParams.Any() ? "?" + GenerateUrlStringFromDict(localParams) : String.Empty);
         }
 
-        private String
-            GenerateSrcSetDPR(
-            String domain,
+        public String BuildSrcSet(String path)
+        {
+            return BuildSrcSet(path, new Dictionary<string, string>());
+        }
+
+        public String BuildSrcSet(String path, Dictionary<String, String> parameters)
+        {
+            return BuildSrcSet(path, parameters, MinWidth, MaxWidth, SrcSetWidthTolerance);
+        }
+
+        /// <summary>
+        /// Create a srcset attribute by disabling variable output quality.
+        ///
+        /// Variable output quality for dpr-based srcset attributes
+        /// is _on by default_. Setting `disableVariableQuality` to
+        /// `true` disables this.
+        /// 
+        /// </summary>
+        /// <param name="path">path to the image, i.e. "image/file.png"</param>
+        /// <param name="parameters">dictionary of query parameters</param>
+        /// <param name="disableVariableQuality">toggle variable quality output on
+        /// (default/false) or off (true).</param>
+        /// <returns></returns>
+        public String BuildSrcSet(
             String path,
             Dictionary<String, String> parameters,
-            Boolean disableVariableQuality)
+            Boolean disableVariableQuality = false)
+        {
+            // Pass off to 6-param overload.
+            return BuildSrcSet(
+                path,
+                parameters,
+                MinWidth,
+                MaxWidth,
+                SrcSetWidthTolerance,
+                disableVariableQuality);
+        }
+
+        /// <summary>
+        /// Create a srcset attribute by specifying `tol`erance.
+        /// </summary>
+        /// <param name="path">path to the image, i.e. "image/file.png"</param>
+        /// <param name="parameters">dictionary of query parameters</param>
+        /// <param name="tol">tolerable amount of width value variation, 1-100.</param>
+        /// <returns>srcset attribute string</returns>
+        public String BuildSrcSet(
+            String path,
+            Dictionary<String, String> parameters,
+            int tol = SrcSetWidthTolerance)
+        {
+            return BuildSrcSet(path, parameters, MinWidth, MaxWidth, tol);
+        }
+
+        /// <summary>
+        /// Create a a srcset attribute by specifying `begin` and `end`.
+        ///
+        /// This method creates a srcset attribute string whose image width
+        /// values range between `begin` and `end`.
+        /// 
+        /// </summary>
+        /// <param name="begin">beginning (min) image width value</param>
+        /// <param name="end">ending (max) image width value</param>
+        /// <returns>srcset attribute string</returns>
+        public String BuildSrcSet(
+            String path,
+            Dictionary<String, String> parameters,
+            int begin = MinWidth,
+            int end = MaxWidth)
+        {
+            return BuildSrcSet(path, parameters, begin, end, SrcSetWidthTolerance);
+        }
+
+        /// <summary>
+        /// Create a a srcset attribute by specifying `begin`, `end`, and `tol`.
+        ///
+        /// This method creates a srcset attribute string whose image width
+        /// values range between `begin` and `end` with the specified amount
+        /// `tol`erance between each.
+        /// 
+        /// </summary>
+        /// <param name="begin">beginning (min) image width value</param>
+        /// <param name="end">ending (max) image width value</param>
+        /// <param name="tol">tolerable amount of width value variation, 1-100.</param>
+        /// <returns>srcset attribute string</returns>
+        public String BuildSrcSet(
+            String path,
+            Dictionary<String, String> parameters,
+            int begin = MinWidth,
+            int end = MaxWidth,
+            int tol = SrcSetWidthTolerance)
+        {
+            return BuildSrcSet(path, parameters, begin, end, tol, false);
+        }
+
+        /// <summary>
+        /// Create a srcset attribute.
+        ///
+        /// If the `parameters` indicate the srcset attribute should be
+        /// dpr-based, then a dpr-based srcset is created.
+        ///
+        /// Otherwise, a viewport based srcset attribute is created with
+        /// with the target widths that are generated by using `begin`,
+        /// `end`, and `tol`.
+        /// </summary>
+        /// <param name="path">path to the image, i.e. "image/file.png"</param>
+        /// <param name="parameters">dictionary of query parameters</param>
+        /// <param name="begin">beginning (min) image width value</param>
+        /// <param name="end">ending (max) image width value</param>
+        /// <param name="tol">tolerable amount of width value variation, 1-100.</param>
+        /// <param name="disableVariableQuality">toggle variable quality output on
+        /// (default/false) or off (true).</param>
+        /// <returns></returns>
+        public String BuildSrcSet(
+            String path,
+            Dictionary<String, String> parameters,
+            int begin = MinWidth,
+            int end = MaxWidth,
+            int tol = SrcSetWidthTolerance,
+            Boolean disableVariableQuality = false)
+        {
+
+            if (IsDpr(parameters))
+            {
+                return GenerateSrcSetDPR(path, parameters, disableVariableQuality);
+            }
+            else
+            {
+                List<int> targets = GenerateTargetWidths(begin: begin, end: end, tol: tol);
+                return GenerateSrcSetPairs(path, parameters, targets: targets);
+            }
+        }
+
+        private String
+            GenerateSrcSetDPR(
+                String path,
+                Dictionary<String, String> parameters,
+                Boolean disableVariableQuality)
         {
             String srcset = "";
-            int[] targetRatios = { 1, 2, 3, 4, 5 };
+            var srcSetParams = new Dictionary<String, String>(parameters);
 
+            // If a "q" is present, it will be applied whether or not
+            // variable quality has been disabled.
             Boolean hasQuality = parameters.TryGetValue("q", out String q);
-            foreach(int ratio in targetRatios)
+
+            foreach(int ratio in DprRatios)
             {
                 if (!disableVariableQuality && !hasQuality)
                 {
-                    parameters["q"] = DPR_QUALITIES[ratio].ToString();
+                    srcSetParams["q"] = DprQualities[ratio - 1].ToString();
                 }
-                parameters["dpr"] = ratio.ToString();
-                srcset += BuildUrl(path, parameters) + " " + ratio.ToString()+ "x,\n";
+                srcSetParams["dpr"] = ratio.ToString();
+                srcset += BuildUrl(path, srcSetParams) + " " + ratio.ToString()+ "x,\n";
             }
 
             return srcset.Substring(0, srcset.Length - 2);
         }
 
         private String GenerateSrcSetPairs(
-            String domain,
             String path,
             Dictionary<String, String> parameters,
             List<int> targets = null)
         {
             if (targets == null)
             {
-                targets = GenerateTargetWidths();
+                targets = SrcSetTargetWidths.ToList();
             }
 
             String srcset = "";
@@ -162,35 +269,104 @@ namespace Imgix
             return srcset.Substring(0, srcset.Length - 2);
         }
 
+        /// <summary>
+        /// Create a `List` of integer target widths.
+        ///
+        /// If `begin`, `end`, and `tol` are the default values, then the
+        /// targets are not custom, in which case the default widths are
+        /// returned.
+        ///
+        /// A target width list of length one is valid: if `begin` == `end`
+        /// then the list begins where it ends.
+        /// 
+        /// When the `while` loop terminates, `begin` is greater than `end`
+        /// (where `end` less than or equal to `MAX_WIDTH`). This means that
+        /// the most recently appended value may, or may not, be the `end`
+        /// value.
+        /// 
+        /// To be inclusive of the ending value, we check for this case and the
+        /// value is added if necessary.
+        /// </summary>
+        /// <param name="begin">beginning (min) image width value</param>
+        /// <param name="end">ending (max) image width value</param>
+        /// <param name="tol">tolerable amount of width value variation, 1-100.</param>
+        /// <returns>list of image width values</returns>        
         public static List<int>
             GenerateTargetWidths(
-                double start = 100, double stop = 8192, double tol = 8)
+                int begin = MinWidth,
+                int end = MaxWidth,
+                int tol = SrcSetWidthTolerance)
         {
-            int MAX_SIZE = 8192;
+            return ComputeTargetWidths(begin, end, tol);
+        }
 
-            if (start == stop)
+        public static List<int> GenerateEvenTargetWidths()
+        {
+            return SrcSetTargetWidths.ToList();
+        }
+
+        /**
+         * Create an `ArrayList` of integer target widths.
+         *
+         * This function is the implementation details of `targetWidths`.
+         * This function exists to provide a consistent interface for
+         * callers of `targetWidths`.
+         *
+         * This function implements the syntax that fulfills the semantics
+         * of `targetWidths`. Meaning, `begin`, `end`, and `tol` are
+         * to be whole integers, but computation requires `double`s. This
+         * function hides this detail from callers.
+         */
+        private static List<int> ComputeTargetWidths(double begin, double end, double tol)
+        {
+            if(NotCustom(begin, end, tol))
             {
-                return new List<int> {MakeEven(start)};
+                // If not custom, return the default target widths.
+                return SrcSetTargetWidths.ToList();
+            }
+
+            if (begin == end)
+            {
+                return new List<int> {(int) Math.Round(begin) };
             }
 
             List<int> resolutions = new List<int>();
-            while (start < stop && start < MAX_SIZE)
+            while (begin < end && begin < MaxWidth)
             {
-                resolutions.Add(MakeEven(start));
-                start *= 1 + (tol / 100) * 2;
+                resolutions.Add((int) Math.Round(begin));
+                begin *= 1 + (tol / 100) * 2;
             }
 
-            if (resolutions.Last() < stop)
+            if (resolutions.Last() < end)
             {
-                resolutions.Add(MakeEven(stop));
+                resolutions.Add((int) Math.Round(end));
             }
 
             return resolutions;
+
         }
 
-        private static int MakeEven(double value)
+        private static Boolean IsDpr(Dictionary<String, String> parameters)
         {
-            return (int)(2 * Math.Round(value / 2));
+            Boolean hasWidth = parameters.TryGetValue("w", out String width);
+            Boolean hasHeight = parameters.TryGetValue("h", out String height);
+            Boolean hasAspectRatio = parameters.TryGetValue("ar", out String aspectRatio);
+
+            // If `params` have a width param or _both_ height and aspect
+            // ratio parameters then the srcset to be constructed with
+            // these params _is dpr based_
+            return hasWidth || (hasHeight && hasAspectRatio);
+        }
+
+        private static Boolean NotCustom(double begin, double end, double tol)
+        {
+            Boolean defaultBegin = (begin == MinWidth);
+            Boolean defaultEnd = (end == MaxWidth);
+            Boolean defaultTol = (tol == SrcSetWidthTolerance);
+
+            // A list of target widths is _NOT_ custom if `begin`, `end`,
+            // and `tol` are equal to their default values.
+            return defaultBegin && defaultEnd && defaultTol;
         }
 
         private String HashString(String input)

--- a/src/Imgix/Validator.cs
+++ b/src/Imgix/Validator.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+namespace Imgix
+{
+    public class Validator
+    {
+        private static readonly double ONE_PERCENT = 0.01;
+
+        /// <summary>
+        /// Validate `begin` width value is at least zero.
+        /// </summary>
+        /// <param name="begin">Beginning width value of a width-range.</param>
+        /// <exception cref="Exception">Throws, if `begin` is less than zero.</exception>
+        public static void ValidateMinWidth(int begin)
+        {
+            if (begin < 0)
+            {
+                throw new Exception("`begin` width value must be greater than zero");
+            }
+        }
+
+        /// <summary>
+        /// Validate `end` width value is at greater than or equal to zero.
+        /// </summary>
+        /// <param name="end">Ending width value of a width-range.</param>
+        /// <exception cref="Exception">Throws, if `end` is less than zero.</exception>
+        public static void ValidateMaxWidth(int end)
+        {
+            if (end < 0)
+            {
+                throw new Exception("`end` width value must be greater than zero");
+            }
+        }
+
+        /// <summary>
+        /// Validate `begin` and `end` represent a valid width-range.
+        ///
+        /// This validator is the composition of `validateMinWidth` and
+        /// `validateMaxWidth`. It also adds a final constraint that
+        /// `begin` be less than or equal to `end`
+        /// </summary>
+        /// <param name="begin">Beginning width value of a width-range</param>
+        /// <param name="end">Ending width value of a width-range.</param>
+        /// <exception cref="Exception">Throws, if a width range `begin`s after it `end`s.</exception>
+        public static void ValidateRange(int begin, int end)
+        {
+            // Validate the minimum width, `begin`.
+            ValidateMinWidth(begin);
+            // Validate the maximum width, `end`.
+            ValidateMaxWidth(end);
+
+            // Ensure that the range is valid, ie. `begin <= end`.
+            if (end < begin)
+            {
+                throw new Exception("`begin` width value must be less than `end` width value");
+            }
+        }
+
+        /// <summary>
+        /// Validate `tol`erance is at least `ONE_PERCENT`.
+        /// </summary>
+        /// <param name="tol">Tolerable amount of image width variation.</param>
+        /// <exception cref="Exception">Throws, if `tol` is less than `ONE_PERCENT`..</exception>
+        public static void ValidateTolerance(double tol)
+        {
+            String msg = "`tol`erance value must be greater than, " +
+                "or equal to one percent, ie. >= 0.01";
+
+            if (tol < ONE_PERCENT)
+            {
+                throw new Exception(msg);
+            }
+        }
+
+        /// <summary>
+        /// Validate that `begin`, `end`, and `tol` represent a valid srcset range.
+        /// </summary>
+        /// <param name="begin">Beginning width value of a width-range.</param>
+        /// <param name="end">Ending width value of a width-range.</param>
+        /// <param name="tol">Tolerable amount of image width variation.</param>
+        /// <exception cref="Exception">Throws, if validation of `begin`, `end`,
+        /// or `tol` fails.</exception>
+        public static void ValidateMinMaxTol(int begin, int end, double tol)
+        {
+            ValidateRange(begin, end);
+            ValidateTolerance(tol);
+        }
+
+        /// <summary>
+        /// Validate `widths` array contains only positive values.
+        /// </summary>
+        /// <param name="widths">Integer array of positive image width values.</param>
+        /// <exception cref="Exception">Throws, if `widths` is empty,`null`,
+        /// or contains negative values.</exception>
+        public static void ValidateWidths(List<int> widths)
+        {
+            if (widths == null)
+            {
+                throw new Exception("`widths` array cannot be `null`");
+            }
+
+            if (widths.Count == 0)
+            {
+                throw new Exception("`widths` array cannot be empty");
+            }
+
+            foreach (int w in widths)
+            {
+                if (w < 0)
+                {
+                    throw new Exception("width values in `widths` cannot be negative");
+                }
+            }
+        }
+    }
+}

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -577,6 +577,9 @@ namespace Imgix.Tests
         public void TargetWidths328to4088()
         {
             List<int> actual = UrlBuilder.GenerateTargetWidths(start: 328, stop: 4088);
+            // `GenerateTargetWidths` depends on the start value; consequently,
+            // values between `start` and `stop` may be a couple pixels above
+            // (and perhaps below) our defaults (if tolerance is default).
             int[] expected = {
                 328, 380, 442, 512, 594, 688,
                 /* 798 */ 800,
@@ -643,6 +646,54 @@ namespace Imgix.Tests
                 tol: 1);
 
             Assert.AreEqual(expect100to108, srcset100to108);
+        }
+
+        [Test]
+        public void TestDprSrcSetWithDefaultQuality()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "test.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            var parameters = new Dictionary<string, string>() { { "w", "100" } };
+            String srcset = ub.BuildSrcSet("image.jpg", parameters);
+
+            String expected =
+            "https://test.imgix.net/image.jpg?w=100&q=75&dpr=1 1x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&q=50&dpr=2 2x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&q=35&dpr=3 3x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&q=23&dpr=4 4x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&q=20&dpr=5 5x";
+
+            Assert.AreEqual(expected, srcset);
+        }
+
+        [Test]
+        public void TestDprSrcSetWithVariableQualityDisabled()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "test.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            var parameters = new Dictionary<string, string>() { { "w", "100" } };
+
+            String srcset = ub.BuildSrcSet(
+                "image.jpg",
+                parameters,
+                disableVariableQuality: true);
+
+            String expected =
+            "https://test.imgix.net/image.jpg?w=100&dpr=1 1x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=2 2x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=3 3x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=4 4x," +
+            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=5 5x";
+
+            Assert.AreEqual(expected, srcset);
         }
     }
 }

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -559,5 +559,46 @@ namespace Imgix.Tests
                 Assert.True(src.Contains(String.Format("dpr={0}", i + 1)));
             }
         }
+
+        [Test]
+        public void TargetWidths100to7400()
+        {
+            List<int> actual = UrlBuilder.GenerateTargetWidths(start: 100, stop: 7400);
+            int[] expected = {
+                100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400 };
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TargetWidths328to4088()
+        {
+            List<int> actual = UrlBuilder.GenerateTargetWidths(start: 328, stop: 4088);
+            int[] expected = {
+                328, 380, 442, 512, 594, 688,
+                /* 798 */ 800,
+                /* 926 */ 928,
+                /* 1074 */ 1076, 1248, 1446, 1678,
+                1948, 2258,
+                /* 2620 */ 2620,
+                /* 3038 */ 3040,
+                /* 3524 */ 3526, 4088};
+
+            Assert.AreEqual(expected, actual);
+
+        }
+
+        [Test]
+        public void TargetWidths100to8192MaxTolerance()
+        {
+            List<int> actual = UrlBuilder.GenerateTargetWidths(tol: 100000000);
+            int[] expected = { 100, 8192 };
+
+            Assert.AreEqual(expected, actual);
+
+        }
     }
 }

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -644,6 +644,32 @@ namespace Imgix.Tests
         }
 
         [Test]
+        public void TestSrcSetPairsWithCustomTargets()
+        {
+            UrlBuilder ub = new UrlBuilder(
+               "test.imgix.net",
+               signKey: null,
+               includeLibraryParam: false,
+               useHttps: true);
+
+            String expect100to513 =
+                "https://test.imgix.net/image.jpg?w=100 100w,\n" +
+                "https://test.imgix.net/image.jpg?w=200 200w,\n" +
+                "https://test.imgix.net/image.jpg?w=300 300w,\n" +
+                "https://test.imgix.net/image.jpg?w=400 400w,\n" +
+                "https://test.imgix.net/image.jpg?w=513 513w";
+
+            int[] targetWidths = {100, 200, 300, 400, 513};
+
+            String srcset100to513 = ub.BuildSrcSet(
+                "image.jpg",
+                new Dictionary<string, string>(),
+                targetWidths.ToList());
+
+            Assert.AreEqual(expect100to513, srcset100to513);
+        }
+
+        [Test]
         public void TestDisableVariableQualityOffByDefault()
         {
             UrlBuilder ub = new UrlBuilder(

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using Imgix;
 using System.Security.Cryptography;
 using System.Linq;
 
@@ -638,7 +637,7 @@ namespace Imgix.Tests
                 new Dictionary<string, string>(),
                 begin: 100,
                 end: 108,
-                tol: 1);
+                tol: 0.01);
 
             Assert.AreEqual(expect100to108, srcset100to108);
         }

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -67,10 +67,11 @@ namespace Imgix.Tests
         [Test]
         public void NoParametersGeneratesCorrectWidths()
         {
-            int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+            int[] targetWidths = {
+                100, 116, 135, 156, 181, 210, 244, 283,
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1446, 1678, 1946, 2257, 2619,
+                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
             String generatedWidth;
             int index = 0;
@@ -207,10 +208,11 @@ namespace Imgix.Tests
         [Test]
         public void HeightGeneratesCorrectWidths()
         {
-            int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+            int[] targetWidths = {
+                100, 116, 135, 156, 181, 210, 244, 283,
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1446, 1678, 1946, 2257, 2619,
+                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
             String generatedWidth;
             int index = 0;
@@ -359,10 +361,11 @@ namespace Imgix.Tests
         [Test]
         public void AspectRatioGeneratesCorrectWidths()
         {
-            int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+            int[] targetWidths = {
+                100, 116, 135, 156, 181, 210, 244, 283,
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1446, 1678, 1946, 2257, 2619,
+                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
             String generatedWidth;
             int index = 0;
@@ -563,32 +566,23 @@ namespace Imgix.Tests
         [Test]
         public void TargetWidths100to7400()
         {
-            List<int> actual = UrlBuilder.GenerateTargetWidths(start: 100, stop: 7400);
+            List<int> actual = UrlBuilder.GenerateTargetWidths(begin: 100, end: 7401);
             int[] expected = {
-                100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400 };
-
+                100, 116, 135, 156, 181, 210, 244, 283,
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1446, 1678, 1946, 2257, 2619,
+                3038, 3524, 4087, 4741, 5500, 6380, 7401};
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
         public void TargetWidths328to4088()
         {
-            List<int> actual = UrlBuilder.GenerateTargetWidths(start: 328, stop: 4088);
-            // `GenerateTargetWidths` depends on the start value; consequently,
-            // values between `start` and `stop` may be a couple pixels above
-            // (and perhaps below) our defaults (if tolerance is default).
+            List<int> actual = UrlBuilder.GenerateTargetWidths(begin: 328, end: 4088);
             int[] expected = {
-                328, 380, 442, 512, 594, 688,
-                /* 798 */ 800,
-                /* 926 */ 928,
-                /* 1074 */ 1076, 1248, 1446, 1678,
-                1948, 2258,
-                /* 2620 */ 2620,
-                /* 3038 */ 3040,
-                /* 3524 */ 3526, 4088};
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1447, 1678, 1947, 2259, 2620,
+                3039, 3525, 4088};
 
             Assert.AreEqual(expected, actual);
 
@@ -613,43 +607,44 @@ namespace Imgix.Tests
                 includeLibraryParam: false,
                 useHttps: true);
 
+            // Begin == End
             String srcset = ub.BuildSrcSet(
                 "image.jpg",
                 new Dictionary<string, string>(),
-                start: 328, stop: 328);
+                begin: 328, end: 328);
 
             Assert.AreEqual("https://test.imgix.net/image.jpg?w=328 328w", srcset);
 
             String srcset640to720 = ub.BuildSrcSet(
                 "image.jpg",
                 new Dictionary<string, string>(),
-                start: 640, stop: 720);
+                begin: 640, end: 720);
 
             String expect640to720 =
-                "https://test.imgix.net/image.jpg?w=640 640w," +
-                "\nhttps://test.imgix.net/image.jpg?w=720 720w";
+                "https://test.imgix.net/image.jpg?w=640 640w,\n" +
+                "https://test.imgix.net/image.jpg?w=720 720w";
 
             Assert.AreEqual(expect640to720, srcset640to720);
 
             String expect100to108 =
-                "https://test.imgix.net/image.jpg?w=100 100w," +
-                "\nhttps://test.imgix.net/image.jpg?w=102 102w," +
-                "\nhttps://test.imgix.net/image.jpg?w=104 104w," +
-                "\nhttps://test.imgix.net/image.jpg?w=106 106w," +
-                "\nhttps://test.imgix.net/image.jpg?w=108 108w";
+                "https://test.imgix.net/image.jpg?w=100 100w,\n" +
+                "https://test.imgix.net/image.jpg?w=102 102w,\n" +
+                "https://test.imgix.net/image.jpg?w=104 104w,\n" +
+                "https://test.imgix.net/image.jpg?w=106 106w,\n" +
+                "https://test.imgix.net/image.jpg?w=108 108w";
 
             String srcset100to108 = ub.BuildSrcSet(
                 "image.jpg",
                 new Dictionary<string, string>(),
-                start: 100,
-                stop: 108,
+                begin: 100,
+                end: 108,
                 tol: 1);
 
             Assert.AreEqual(expect100to108, srcset100to108);
         }
 
         [Test]
-        public void TestDprSrcSetWithDefaultQuality()
+        public void TestDisableVariableQualityOffByDefault()
         {
             UrlBuilder ub = new UrlBuilder(
                 "test.imgix.net",
@@ -661,17 +656,17 @@ namespace Imgix.Tests
             String srcset = ub.BuildSrcSet("image.jpg", parameters);
 
             String expected =
-            "https://test.imgix.net/image.jpg?w=100&q=75&dpr=1 1x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&q=50&dpr=2 2x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&q=35&dpr=3 3x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&q=23&dpr=4 4x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&q=20&dpr=5 5x";
+            "https://test.imgix.net/image.jpg?w=100&q=75&dpr=1 1x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&q=50&dpr=2 2x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&q=35&dpr=3 3x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&q=23&dpr=4 4x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&q=20&dpr=5 5x";
 
             Assert.AreEqual(expected, srcset);
         }
 
         [Test]
-        public void TestDprSrcSetWithVariableQualityDisabled()
+        public void TestDisableVariableQuality()
         {
             UrlBuilder ub = new UrlBuilder(
                 "test.imgix.net",
@@ -684,14 +679,67 @@ namespace Imgix.Tests
             String srcset = ub.BuildSrcSet(
                 "image.jpg",
                 parameters,
-                disableVariableQuality: true);
+                disableVariableQuality: true); // disable variable quality
 
             String expected =
-            "https://test.imgix.net/image.jpg?w=100&dpr=1 1x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=2 2x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=3 3x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=4 4x," +
-            "\nhttps://test.imgix.net/image.jpg?w=100&dpr=5 5x";
+            "https://test.imgix.net/image.jpg?w=100&dpr=1 1x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&dpr=2 2x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&dpr=3 3x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&dpr=4 4x,\n" +
+            "https://test.imgix.net/image.jpg?w=100&dpr=5 5x";
+
+            Assert.AreEqual(expected, srcset);
+        }
+
+        [Test]
+        public void TestDisableVariableQualityWithQuality()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "test.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: false);
+
+            var parameters = new Dictionary<string, string>() { { "w", "100" }, { "q", "99" } };
+
+            String srcset = ub.BuildSrcSet(
+                "image.png",
+                parameters,
+                disableVariableQuality: true); // disable variable quality
+
+            String expected =
+                "http://test.imgix.net/image.png?w=100&q=99&dpr=1 1x,\n" +
+                "http://test.imgix.net/image.png?w=100&q=99&dpr=2 2x,\n" +
+                "http://test.imgix.net/image.png?w=100&q=99&dpr=3 3x,\n" +
+                "http://test.imgix.net/image.png?w=100&q=99&dpr=4 4x,\n" +
+                "http://test.imgix.net/image.png?w=100&q=99&dpr=5 5x";
+
+            Assert.AreEqual(expected, srcset);
+        }
+
+        [Test]
+        public void TestVariableQualityEnabledWithQ()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "test.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            // Pass "q" with variable quality enabled.
+            var parameters = new Dictionary<string, string>() { { "ar", "2:3"}, { "h", "100" }, { "q", "99" } };
+
+            String srcset = ub.BuildSrcSet(
+                "image.png",
+                parameters,
+                disableVariableQuality: false); // Variable quality enabled.
+
+            String expected =
+                "https://test.imgix.net/image.png?ar=2%3A3&h=100&q=99&dpr=1 1x,\n" +
+                "https://test.imgix.net/image.png?ar=2%3A3&h=100&q=99&dpr=2 2x,\n" +
+                "https://test.imgix.net/image.png?ar=2%3A3&h=100&q=99&dpr=3 3x,\n" +
+                "https://test.imgix.net/image.png?ar=2%3A3&h=100&q=99&dpr=4 4x,\n" +
+                "https://test.imgix.net/image.png?ar=2%3A3&h=100&q=99&dpr=5 5x";
 
             Assert.AreEqual(expected, srcset);
         }

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -600,5 +600,49 @@ namespace Imgix.Tests
             Assert.AreEqual(expected, actual);
 
         }
+
+        [Test]
+        public void TestCustomSrcSetPairs()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "test.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            String srcset = ub.BuildSrcSet(
+                "image.jpg",
+                new Dictionary<string, string>(),
+                start: 328, stop: 328);
+
+            Assert.AreEqual("https://test.imgix.net/image.jpg?w=328 328w", srcset);
+
+            String srcset640to720 = ub.BuildSrcSet(
+                "image.jpg",
+                new Dictionary<string, string>(),
+                start: 640, stop: 720);
+
+            String expect640to720 =
+                "https://test.imgix.net/image.jpg?w=640 640w," +
+                "\nhttps://test.imgix.net/image.jpg?w=720 720w";
+
+            Assert.AreEqual(expect640to720, srcset640to720);
+
+            String expect100to108 =
+                "https://test.imgix.net/image.jpg?w=100 100w," +
+                "\nhttps://test.imgix.net/image.jpg?w=102 102w," +
+                "\nhttps://test.imgix.net/image.jpg?w=104 104w," +
+                "\nhttps://test.imgix.net/image.jpg?w=106 106w," +
+                "\nhttps://test.imgix.net/image.jpg?w=108 108w";
+
+            String srcset100to108 = ub.BuildSrcSet(
+                "image.jpg",
+                new Dictionary<string, string>(),
+                start: 100,
+                stop: 108,
+                tol: 1);
+
+            Assert.AreEqual(expect100to108, srcset100to108);
+        }
     }
 }

--- a/tests/Imgix.Tests/ValidatorTest.cs
+++ b/tests/Imgix.Tests/ValidatorTest.cs
@@ -1,0 +1,79 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace Imgix.Tests
+{
+    [TestFixture]
+    public class ValidatorTest
+    {
+        private const int LessThanZero = -1;
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void TestValidateMinWidth()
+        {
+            // Test `ValidateMinWidth` throws when passed negative values.
+            Validator.ValidateMinWidth(LessThanZero);
+        }
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void TestValidateMaxWidth()
+        {
+            // Test `ValidateMaxWidth` throws when passed negative values.
+            Validator.ValidateMaxWidth(LessThanZero);
+        }
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void TestValidateRange()
+        {
+            // Test `ValidateRange` throws when passed mixed up
+            // `begin` and `end` values.
+            // Typically a typo'd call might look like:
+            // `ValidateRange(400, 100)`
+            // this validator seeks to prevent these kinds of errors.
+            const int Begin = 400;
+            const int End = 100;
+            Validator.ValidateRange(Begin, End);
+        }
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void TestValidateTolerance()
+        {
+            // Test `ValidateTolerance` throws when passed values
+            // less than one percent.
+            const double LessThanOnePercent = 0.001;
+            Validator.ValidateTolerance(LessThanOnePercent);
+        }
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void TestValidateNegativeWidthsThrows()
+        {
+            //Test `ValidateWidths` throws if a negative width value
+            // has been found.
+            int[] Widths = { 100, 200, 300, LessThanZero };
+            Validator.ValidateWidths(Widths.ToList());
+        }
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void TestValidateWidthsNullArray()
+        {
+            // Test `ValidateWidths` throws if passed a `null` array.
+            Validator.ValidateWidths(null);
+        }
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void TestValidateToleranceEmptyList()
+        {
+            // Test `ValidateWidths` throws if passed an empty array.
+            Validator.ValidateWidths(new List<int>());
+        }
+    }
+}


### PR DESCRIPTION
This PR implements custom srcsets by extending the parameter lists of
`GenerateTargetWidths`, `BuildSrcSet`,  `GenerateSrcSetDPR`, and
`GenerateSrcSetPairs`.

First, target widths functionality was extended to support `begin`ning
and `end`ing at user-specified target widths where each subsequent
width increases within the specified `tol`erance. This was done to
prepare `GenerateSrcSetPairs` to accept a custom list of target widths.

Finally, `GenerateSrcSetDPR` has been extended to accept the
`disableVariableQuality` flag. When `true`, varied image output
quality is disabled. Passing "q" without disabling variable quality
exhibits the same behavior as passing "q" _and_ disabling variable
quality.

During the development of this feature we decided that
`SrcSetWidthTolerance` should be a `float` i.a.w. our
imgix-core-js implementation.

The last portions implemented here is validation. We validate that
`begin`, `end`, and `tol` represent a valid srcset width range. We
also validate that any custom list of `widths` is not empty, `null`,
or does not contain negative "width" values.