### PR TITLE
feat: demo custom srcset feats in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@
 <!-- /ix-docs-ignore -->
 
 - [Installation](#installation)
-- [Usage](#Usage)
+  - [Version 1.x](#version-1x)
+- [Usage](#usage)
 - [Signed URLs](#signed-urls)
 - [Srcset Generation](#srcset-generation)
-- [What is the ixlib param on every request?](#what-is-the-ixlib-param-on-every-request)
+  - [Fixed-Width Images](#fixed-width-images)
+      - [Variable Quality](#variable-quality)
+  - [Fluid-Width Images](#fluid-width-images)
+    - [Custom Widths](#custom-widths)
+    - [Width Ranges](#width-ranges)
+    - [Width Tolerance](#width-tolerance)
+- [What is the `ixlib` param on every request?](#what-is-the-ixlib-param-on-every-request)
 - [Code of Conduct](#code-of-conduct)
 
 ## Installation
@@ -85,13 +92,17 @@ Will produce the following attribute value, which can then be served to the clie
 ```html
 https://domain.imgix.net/bridge.png?w=100&s=494158d968e94ac8e83772ada9a83ad1 100w,
 https://domain.imgix.net/bridge.png?w=116&s=6a22236e189b6a9548b531330647ffa7 116w,
-https://domain.imgix.net/bridge.png?w=134&s=cbf91f556dd67c0b9e26cb9784a83794 134w,
+https://domain.imgix.net/bridge.png?w=135&s=cbf91f556dd67c0b9e26cb9784a83794 135w,
                                             ...
-https://domain.imgix.net/bridge.png?w=7400&s=503e3ba04588f1c301863c9a5d84fe91 7400w,
+https://domain.imgix.net/bridge.png?w=7401&s=503e3ba04588f1c301863c9a5d84fe91 7401w,
 https://domain.imgix.net/bridge.png?w=8192&s=152551ce4ec155f7a03f60f762a1ca33 8192w
 ```
 
-In cases where enough information is provided about an image's dimensions, `BuildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w` (width), `h` (height), and `ar` (aspect ratio). By invoking `BuildSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
+### Fixed-Width Images
+
+In cases where enough information is provided about an image's dimensions, `BuildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w` (width), `h` (height), and `ar` (aspect ratio).
+
+By invoking `BuildSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
 ```csharp
 var builder = new UrlBuilder("domain.imgix.net", "my-token", false, true);
@@ -114,6 +125,129 @@ https://domain.imgix.net/bridge.png?h=200&ar=3%3A2&fit=crop&dpr=5&s=ce70bbfd682e
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
+
+##### Variable Quality
+
+This library will automatically append a variable `q` parameter mapped to each `dpr` parameter when generating a [fixed-width image](#fixed-width-images) srcset. This technique is commonly used to compensate for the increased file size of high-DPR images.
+
+Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall file size without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality).
+
+This behavior will respect any overriding `q` value passed in as a parameter. Additionally, it can be disabled altogether by passing `disableVariableQuality = true` to `BuildSrcSet`.
+
+This behavior specifically occurs when a [fixed-width image](#fixed-width-images) is rendered, for example:
+
+```c#
+UrlBuilder ub = new UrlBuilder(
+    "demo.imgix.net",
+    signKey: null,
+    includeLibraryParam: false,
+    useHttps: true);
+
+var params = new Dictionary<string, string>() { { "w", "100" } };
+
+String srcset = ub.BuildSrcSet("image.jpg", params); // Variable quality enabled by default.
+```
+
+The above will generate a srcset with the following `q` to `dpr` query `params`:
+
+```html
+https://demo.imgix.net/image.jpg?dpr=1&q=75&w=100 1x,
+https://demo.imgix.net/image.jpg?dpr=2&q=50&w=100 2x,
+https://demo.imgix.net/image.jpg?dpr=3&q=35&w=100 3x,
+https://demo.imgix.net/image.jpg?dpr=4&q=23&w=100 4x,
+https://demo.imgix.net/image.jpg?dpr=5&q=20&w=100 5x
+```
+
+### Fluid-Width Images
+
+#### Custom Widths
+In situations where specific widths are desired when generating `srcset` pairs, a user can specify them by passing an array of positive integers as `widths`:
+
+```c#
+UrlBuilder ub = new UrlBuilder(
+    "demo.imgix.net",
+    signKey: null,
+    includeLibraryParam: false,
+    useHttps: true);
+
+int[] widths = { 144, 240, 320, 446, 640 };
+Dictionary<string, string> parameters = new Dictionary<string, string>();
+String srcset = ub.BuildSrcSet("image.jpg", parameters, widths.ToList());
+```
+
+```html
+https://demo.imgix.net/image.jpg?w=144 144w,
+https://demo.imgix.net/image.jpg?w=240 240w,
+https://demo.imgix.net/image.jpg?w=320 320w,
+https://demo.imgix.net/image.jpg?w=446 446w,
+https://demo.imgix.net/image.jpg?w=640 640w
+```
+
+**Note**: in situations where a `srcset` is being rendered as a [fixed image](#fixed-image-rendering), any custom `widths` passed in will be ignored.
+
+Additionally, if both `widths` and a width `tol`erance are passed to the `BuildSrcSet` method, the custom widths list will take precedence.
+
+#### Width Ranges
+
+In certain circumstances, you may want to limit the minimum or maximum value of the non-fixed (fluid-width) `srcset` generated by the `BuildSrcSet` method. To do this, you can specify the widths at which a srcset should `begin` and `end`:
+
+```c#
+UrlBuilder ub = new UrlBuilder(
+    "demo.imgix.net",
+    signKey: null,
+    includeLibraryParam: false,
+    useHttps: true);
+
+Dictionary<string, string> parameters = new Dictionary<string, string>();
+String srcset = ub.BuildSrcSet("image.jpg", parameters, 500, 2000);
+```
+
+Formatted version of the above srcset attribute:
+
+``` html
+https://demo.imgix.net/image.jpg?w=500 500w,
+https://demo.imgix.net/image.jpg?w=580 580w,
+https://demo.imgix.net/image.jpg?w=673 673w,
+https://demo.imgix.net/image.jpg?w=780 780w,
+https://demo.imgix.net/image.jpg?w=905 905w,
+https://demo.imgix.net/image.jpg?w=1050 1050w,
+https://demo.imgix.net/image.jpg?w=1218 1218w,
+https://demo.imgix.net/image.jpg?w=1413 1413w,
+https://demo.imgix.net/image.jpg?w=1639 1639w,
+https://demo.imgix.net/image.jpg?w=1901 1901w,
+https://demo.imgix.net/image.jpg?w=2000 2000w
+```
+
+#### Width Tolerance
+
+The `srcset` width `tol`erance dictates the maximum `tol`erated difference between an image's downloaded size and its rendered size.
+
+For example, setting this value to 0.1 means that an image will not render more than 10% larger or smaller than its native size. In practice, the image URLs generated for a width-based srcset attribute will grow by twice this rate.
+
+A lower tolerance means images will render closer to their native size (thereby increasing perceived image quality), but a large srcset list will be generated and consequently users may experience lower rates of cache-hit for pre-rendered images on your site.
+
+By default, srcset width `tol`erance is set to 0.08 (8 percent), which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by providing a positive scalar value as width `tol`erance:
+
+```csharp
+UrlBuilder ub = new UrlBuilder(
+    "demo.imgix.net",
+    signKey: null,
+    includeLibraryParam: false,
+    useHttps: true);
+
+Dictionary<string, string> parameters = new Dictionary<string, string>();
+String srcset = ub.BuildSrcSet("image.jpg", parameters, 100, 384, 0.20);
+```
+
+In this case, the width `tol`erance is set to 20 percent, which will be reflected in the difference between subsequent widths in a srcset pair:
+
+```html
+https://demo.imgix.net/image.jpg?w=100 100w,
+https://demo.imgix.net/image.jpg?w=140 140w,
+https://demo.imgix.net/image.jpg?w=196 196w,
+https://demo.imgix.net/image.jpg?w=274 274w,
+https://demo.imgix.net/image.jpg?w=384 384w
+```
 
 ## What is the `ixlib` param on every request?
 

--- a/tests/Imgix.Tests/ReadMeTest.cs
+++ b/tests/Imgix.Tests/ReadMeTest.cs
@@ -1,0 +1,111 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace Imgix.Tests
+{
+    [TestFixture]
+    public class ReadMeTest
+    {
+        [Test]
+        public void TestVariableQualityDefault()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "demo.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            Dictionary<string, string>
+                parameters = new Dictionary<string, string>() { { "w", "100" } };
+
+            String srcset = ub.BuildSrcSet(
+                "image.jpg",
+                parameters,
+                disableVariableQuality: false); // Variable quality enabled.
+
+            String expected =
+                "https://demo.imgix.net/image.jpg?w=100&q=75&dpr=1 1x,\n" +
+                "https://demo.imgix.net/image.jpg?w=100&q=50&dpr=2 2x,\n" +
+                "https://demo.imgix.net/image.jpg?w=100&q=35&dpr=3 3x,\n" +
+                "https://demo.imgix.net/image.jpg?w=100&q=23&dpr=4 4x,\n" +
+                "https://demo.imgix.net/image.jpg?w=100&q=20&dpr=5 5x";
+
+            Assert.AreEqual(expected, srcset);
+        }
+
+        [Test]
+        public void TestCustomWidths()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "demo.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            int[] widths = { 144, 240, 320, 446, 640 };
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+            String srcset = ub.BuildSrcSet("image.jpg", parameters, widths.ToList());
+
+            String expected =
+                "https://demo.imgix.net/image.jpg?w=144 144w,\n" +
+                "https://demo.imgix.net/image.jpg?w=240 240w,\n" +
+                "https://demo.imgix.net/image.jpg?w=320 320w,\n" +
+                "https://demo.imgix.net/image.jpg?w=446 446w,\n" +
+                "https://demo.imgix.net/image.jpg?w=640 640w";
+
+            Assert.AreEqual(expected, srcset);
+        }
+
+        [Test]
+        public void TestCustomWidthRange()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "demo.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+            String srcset = ub.BuildSrcSet("image.jpg", parameters, 500, 2000);
+
+            String expected =
+                "https://demo.imgix.net/image.jpg?w=500 500w,\n" +
+                "https://demo.imgix.net/image.jpg?w=580 580w,\n" +
+                "https://demo.imgix.net/image.jpg?w=673 673w,\n" +
+                "https://demo.imgix.net/image.jpg?w=780 780w,\n" +
+                "https://demo.imgix.net/image.jpg?w=905 905w,\n" +
+                "https://demo.imgix.net/image.jpg?w=1050 1050w,\n" +
+                "https://demo.imgix.net/image.jpg?w=1218 1218w,\n" +
+                "https://demo.imgix.net/image.jpg?w=1413 1413w,\n" +
+                "https://demo.imgix.net/image.jpg?w=1639 1639w,\n" +
+                "https://demo.imgix.net/image.jpg?w=1901 1901w,\n" +
+                "https://demo.imgix.net/image.jpg?w=2000 2000w";
+
+            Assert.AreEqual(expected, srcset);
+        }
+
+        [Test]
+        public void TestCustomWidthTolerance()
+        {
+            UrlBuilder ub = new UrlBuilder(
+                "demo.imgix.net",
+                signKey: null,
+                includeLibraryParam: false,
+                useHttps: true);
+
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+            String srcset = ub.BuildSrcSet("image.jpg", parameters, 100, 384, 0.20);
+
+            String expected =
+                "https://demo.imgix.net/image.jpg?w=100 100w,\n" +
+                "https://demo.imgix.net/image.jpg?w=140 140w,\n" +
+                "https://demo.imgix.net/image.jpg?w=196 196w,\n" +
+                "https://demo.imgix.net/image.jpg?w=274 274w,\n" +
+                "https://demo.imgix.net/image.jpg?w=384 384w";
+
+            Assert.AreEqual(expected, srcset);
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the readme for the custom srcsets feature set.

These changes not only reflect the **additional features** added, but
also try to pin down the **semantics** of our **syntax** and
documentation**.

Namely, the differentiation between `fixed` and `fluid-width` srcsets.
We currently construct two types of srcset attributes: those with `fixed`
widths and those with `fluid` widths.

**Fluid-widths vary**. A srcset attribute composed of target width pairs is
described as _fluid_ because each image candidate string denotes a
unique width-described resource.

**Fixed-widths are fixed**. A srcset attribute composed of pixel density
descriptors (ie. `1x, 2x, 3x`) is described as **fixed-width** because width
is held constant, while the pixel density descriptors vary.

Prior to this PR, only default fluid-width srcset attributes could be created.
Now, they can be created by supplying a list of `widths` to `BuildSrcSet`.

Fluid-width sets can also be created by specifying a **widths range**
that `begin`s and `end`s on specified value;. the `tol`erance can also be
specified resulting in more customizable fluid-width srcsets.

Prior to this PR, there was no way to customize the quality of fixed-width
sets. Now, variable quality is enabled by default and can be toggled off
by specifying either:

- `disableVariableQuality=True`, or
- by specifying a `"q"` parameter (i.e. `q=75`)

If`"q"` is supplied, it takes precedence over the default qualities **and**
`disable_variable_quality` **and** it is applied to each image candidate
string (URL) in the srcset attribute.

Lastly, ensure our examples stay current and correct they are
tested in the readme with the remaining tests defined in the
`TestReadMe.java`.