### PR TITLE
fix: dpr srcset when only h param

### DIFF
--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -366,10 +366,9 @@ namespace Imgix
             Boolean hasHeight = parameters.TryGetValue("h", out String height);
             Boolean hasAspectRatio = parameters.TryGetValue("ar", out String aspectRatio);
 
-            // If `params` have a width param or _both_ height and aspect
-            // ratio parameters then the srcset to be constructed with
-            // these params _is dpr based_
-            return hasWidth || (hasHeight && hasAspectRatio);
+            // If `params` have a width param or height parameters then the
+            // srcset to be constructed with these params _is dpr based_
+            return hasWidth || hasHeight;
         }
 
         private static Boolean NotCustom(double begin, double end, double tol)

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -364,7 +364,6 @@ namespace Imgix
         {
             Boolean hasWidth = parameters.TryGetValue("w", out String width);
             Boolean hasHeight = parameters.TryGetValue("h", out String height);
-            Boolean hasAspectRatio = parameters.TryGetValue("ar", out String aspectRatio);
 
             // If `params` have a width param or height parameters then the
             // srcset to be constructed with these params _is dpr based_

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -261,6 +261,18 @@ namespace Imgix.Tests
             }
         }
 
+        [Test]
+        public void testHeightIncludesDPRParam()
+        {
+            String src;
+
+            for (int i = 0; i < srcsetHeightSplit.Length; i++)
+            {
+                src = srcsetHeightSplit[i].Split(' ')[0];
+                Assert.IsTrue(src.Contains(String.Format("dpr={0}", i + 1)));
+            }
+        }
+
         // TODO: remove this test, deprecated
         // [Test]
         // public void HeightDoesNotExceedBounds()

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -246,6 +246,21 @@ namespace Imgix.Tests
             Assert.AreEqual(expectedPairs, srcsetHeightSplit.Length);
         }
 
+        [Test]
+        public void testHeightBasedSrcsetHasDprValues()
+        {
+            String generatedRatio;
+            int expectedRatio = 1;
+            Assert.True(srcsetHeightSplit.Length == 5);
+
+            foreach (String src in srcsetHeightSplit)
+            {
+                generatedRatio = src.Split(' ')[1];
+                Assert.AreEqual(expectedRatio + "x", generatedRatio);
+                expectedRatio++;
+            }
+        }
+
         // TODO: remove this test, deprecated
         // [Test]
         // public void HeightDoesNotExceedBounds()

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -204,27 +204,28 @@ namespace Imgix.Tests
             }
         }
 
-        [Test]
-        public void HeightGeneratesCorrectWidths()
-        {
-            int[] targetWidths = {
-                100, 116, 135, 156, 181, 210, 244, 283,
-                328, 380, 441, 512, 594, 689, 799, 927,
-                1075, 1247, 1446, 1678, 1946, 2257, 2619,
-                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
+        // [Test]
+        // TODO: remove this test, deprecated
+        // public void HeightGeneratesCorrectWidths()
+        // {
+        //     int[] targetWidths = {
+        //         100, 116, 135, 156, 181, 210, 244, 283,
+        //         328, 380, 441, 512, 594, 689, 799, 927,
+        //         1075, 1247, 1446, 1678, 1946, 2257, 2619,
+        //         3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
-            String generatedWidth;
-            int index = 0;
-            int widthInt;
+        //     String generatedWidth;
+        //     int index = 0;
+        //     int widthInt;
 
-            foreach (String src in srcsetHeightSplit)
-            {
-                generatedWidth = src.Split(' ')[1];
-                widthInt = int.Parse(generatedWidth.Substring(0, generatedWidth.Length - 1));
-                Assert.AreEqual(targetWidths[index], widthInt);
-                index++;
-            }
-        }
+        //     foreach (String src in srcsetHeightSplit)
+        //     {
+        //         generatedWidth = src.Split(' ')[1];
+        //         widthInt = int.Parse(generatedWidth.Substring(0, generatedWidth.Length - 1));
+        //         Assert.AreEqual(targetWidths[index], widthInt);
+        //         index++;
+        //     }
+        // }
 
         [Test]
         public void HeightContainsHeightParameter()
@@ -241,44 +242,46 @@ namespace Imgix.Tests
         [Test]
         public void HeightReturnsExpectedNumberOfPairs()
         {
-            int expectedPairs = 31;
+            int expectedPairs = 5;
             Assert.AreEqual(expectedPairs, srcsetHeightSplit.Length);
         }
 
-        [Test]
-        public void HeightDoesNotExceedBounds()
-        {
-            String minWidth = srcsetHeightSplit[0].Split(' ')[1];
-            String maxWidth = srcsetHeightSplit[srcsetHeightSplit.Length - 1].Split(' ')[1];
+        // TODO: remove this test, deprecated
+        // [Test]
+        // public void HeightDoesNotExceedBounds()
+        // {
+        //     String minWidth = srcsetHeightSplit[0].Split(' ')[1];
+        //     String maxWidth = srcsetHeightSplit[srcsetHeightSplit.Length - 1].Split(' ')[1];
 
-            int minWidthInt = int.Parse(minWidth.Substring(0, minWidth.Length - 1));
-            int maxWidthInt = int.Parse(maxWidth.Substring(0, maxWidth.Length - 1));
+        //     int minWidthInt = int.Parse(minWidth.Substring(0, minWidth.Length - 1));
+        //     int maxWidthInt = int.Parse(maxWidth.Substring(0, maxWidth.Length - 1));
 
-            Assert.True(minWidthInt >= 100);
-            Assert.True(maxWidthInt <= 8192);
-        }
+        //     Assert.True(minWidthInt >= 100);
+        //     Assert.True(maxWidthInt <= 8192);
+        // }
 
+        // TODO: remove this test, deprecated
         // a 17% testing threshold is used to account for rounding
-        [Test]
-        public void testHeightDoesNotIncreaseMoreThan17Percent()
-        {
-            const double INCREMENT_ALLOWED = .17;
-            String width;
-            int widthInt, prev;
+        // [Test]
+        // public void testHeightDoesNotIncreaseMoreThan17Percent()
+        // {
+        //     const double INCREMENT_ALLOWED = .17;
+        //     String width;
+        //     int widthInt, prev;
 
-            // convert and store first width (typically: 100)
-            width = srcsetHeightSplit[0].Split(' ')[1];
-            prev = int.Parse(width.Substring(0, width.Length - 1));
+        //     // convert and store first width (typically: 100)
+        //     width = srcsetHeightSplit[0].Split(' ')[1];
+        //     prev = int.Parse(width.Substring(0, width.Length - 1));
 
-            foreach (String src in srcsetHeightSplit)
-            {
-                width = src.Split(' ')[1];
-                widthInt = int.Parse(width.Substring(0, width.Length - 1));
+        //     foreach (String src in srcsetHeightSplit)
+        //     {
+        //         width = src.Split(' ')[1];
+        //         widthInt = int.Parse(width.Substring(0, width.Length - 1));
 
-                Assert.True((widthInt / prev) < (1 + INCREMENT_ALLOWED));
-                prev = widthInt;
-            }
-        }
+        //         Assert.True((widthInt / prev) < (1 + INCREMENT_ALLOWED));
+        //         prev = widthInt;
+        //     }
+        // }
 
         [Test]
         public void testHeightSignsUrls()

--- a/tests/Imgix.Tests/SrcSetTest.cs
+++ b/tests/Imgix.Tests/SrcSetTest.cs
@@ -204,28 +204,6 @@ namespace Imgix.Tests
             }
         }
 
-        // [Test]
-        // TODO: remove this test, deprecated
-        // public void HeightGeneratesCorrectWidths()
-        // {
-        //     int[] targetWidths = {
-        //         100, 116, 135, 156, 181, 210, 244, 283,
-        //         328, 380, 441, 512, 594, 689, 799, 927,
-        //         1075, 1247, 1446, 1678, 1946, 2257, 2619,
-        //         3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
-
-        //     String generatedWidth;
-        //     int index = 0;
-        //     int widthInt;
-
-        //     foreach (String src in srcsetHeightSplit)
-        //     {
-        //         generatedWidth = src.Split(' ')[1];
-        //         widthInt = int.Parse(generatedWidth.Substring(0, generatedWidth.Length - 1));
-        //         Assert.AreEqual(targetWidths[index], widthInt);
-        //         index++;
-        //     }
-        // }
 
         [Test]
         public void HeightContainsHeightParameter()
@@ -272,43 +250,6 @@ namespace Imgix.Tests
                 Assert.IsTrue(src.Contains(String.Format("dpr={0}", i + 1)));
             }
         }
-
-        // TODO: remove this test, deprecated
-        // [Test]
-        // public void HeightDoesNotExceedBounds()
-        // {
-        //     String minWidth = srcsetHeightSplit[0].Split(' ')[1];
-        //     String maxWidth = srcsetHeightSplit[srcsetHeightSplit.Length - 1].Split(' ')[1];
-
-        //     int minWidthInt = int.Parse(minWidth.Substring(0, minWidth.Length - 1));
-        //     int maxWidthInt = int.Parse(maxWidth.Substring(0, maxWidth.Length - 1));
-
-        //     Assert.True(minWidthInt >= 100);
-        //     Assert.True(maxWidthInt <= 8192);
-        // }
-
-        // TODO: remove this test, deprecated
-        // a 17% testing threshold is used to account for rounding
-        // [Test]
-        // public void testHeightDoesNotIncreaseMoreThan17Percent()
-        // {
-        //     const double INCREMENT_ALLOWED = .17;
-        //     String width;
-        //     int widthInt, prev;
-
-        //     // convert and store first width (typically: 100)
-        //     width = srcsetHeightSplit[0].Split(' ')[1];
-        //     prev = int.Parse(width.Substring(0, width.Length - 1));
-
-        //     foreach (String src in srcsetHeightSplit)
-        //     {
-        //         width = src.Split(' ')[1];
-        //         widthInt = int.Parse(width.Substring(0, width.Length - 1));
-
-        //         Assert.True((widthInt / prev) < (1 + INCREMENT_ALLOWED));
-        //         prev = widthInt;
-        //     }
-        // }
 
         [Test]
         public void testHeightSignsUrls()


### PR DESCRIPTION
# Description
This PR ensures a DPR-based SrcSet is generated when a fixed height is the only parameter value.

It removes tests that no longer apply to only having h as a param, and
adds tests that ensure the DPR `sercset` was generated correctly.
