### PR TITLE
chore: change default test command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,10 +21,7 @@
         "-OutputDirectory",
         "testrunner",
       ],
-      "group": {
-        "kind": "test",
-        "isDefault": true
-      },
+      "group": "test",
       "dependsOn": [
         "msbuild: debug"
       ],
@@ -37,7 +34,10 @@
         "./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe",
         "./tests/Imgix.Tests/bin/Debug/net46/Imgix.Tests.dll",
       ],
-      "group": "test",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
       "dependsOn": [
         "nuget: install"
       ]


### PR DESCRIPTION
# Description

I erroneously had the default test command set to `nuget ` and not `mono`, so that when you ran the default `task: test` key-bind, `⇧ + ⌘ + B` for me for example, the tests would not output. 