### PR TITLE
fix(BuildUrl): address path encoding lapses

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "dotnet-test-explorer.testProjectPath":"/tests/Imgix.Tests/Imgix.Tests.csproj"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dotnet-test-explorer.testProjectPath":"/tests/Imgix.Tests/Imgix.Tests.csproj"
+}

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -141,12 +141,12 @@ namespace Imgix
         }
 
         /// <summary>
-        /// Check if the path has one of the four possible acceptable proxy
+        /// Check if the path has one of the three possible acceptable proxy
         /// prefixes. First we check if the path has the correct ascii prefix.
         /// If it does then we know that it is a proxy, but it's not percent
         /// encoded. Second, we check if the path is prefixed by a percent-encoded
         /// prefix. If it is, we know that it's a proxy and that it's percent-encoded.
-        /// Finally, if the path isn't prefixed by any of these four prefixes, it is
+        /// Finally, if the path isn't prefixed by any of these three prefixes, it is
         /// not a valid proxy. This might be "just enough validation," but if we run
         /// into issues we can make this check smarter/more-robust.
         /// </summary>

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -248,14 +248,14 @@ namespace Imgix
             // variable quality has been disabled.
             Boolean hasQuality = parameters.TryGetValue("q", out String q);
 
-            foreach(int ratio in DprRatios)
+            foreach (int ratio in DprRatios)
             {
                 if (!disableVariableQuality && !hasQuality)
                 {
                     srcSetParams["q"] = DprQualities[ratio - 1].ToString();
                 }
                 srcSetParams["dpr"] = ratio.ToString();
-                srcset += BuildUrl(path, srcSetParams) + " " + ratio.ToString()+ "x,\n";
+                srcset += BuildUrl(path, srcSetParams) + " " + ratio.ToString() + "x,\n";
             }
 
             return srcset.Substring(0, srcset.Length - 2);
@@ -273,7 +273,7 @@ namespace Imgix
 
             String srcset = "";
 
-            foreach(int width in targets)
+            foreach (int width in targets)
             {
                 parameters["w"] = width.ToString();
                 srcset += BuildUrl(path, parameters) + " " + width + "w,\n";
@@ -333,7 +333,7 @@ namespace Imgix
          */
         private static List<int> ComputeTargetWidths(double begin, double end, double tol)
         {
-            if(NotCustom(begin, end, tol))
+            if (NotCustom(begin, end, tol))
             {
                 // If not custom, return the default target widths.
                 return SrcSetTargetWidths.ToList();
@@ -341,19 +341,19 @@ namespace Imgix
 
             if (begin == end)
             {
-                return new List<int> {(int) Math.Round(begin) };
+                return new List<int> { (int)Math.Round(begin) };
             }
 
             List<int> resolutions = new List<int>();
             while (begin < end && begin < MaxWidth)
             {
-                resolutions.Add((int) Math.Round(begin));
+                resolutions.Add((int)Math.Round(begin));
                 begin *= 1 + tol * 2;
             }
 
             if (resolutions.Last() < end)
             {
-                resolutions.Add((int) Math.Round(end));
+                resolutions.Add((int)Math.Round(end));
             }
 
             return resolutions;
@@ -396,13 +396,16 @@ namespace Imgix
                         encodedKey = encodedKey.Replace("+", "%20");
                         String encodedVal;
 
-                        if (p.Key.EndsWith("64")) {
+                        if (p.Key.EndsWith("64"))
+                        {
                             Byte[] valBytes = System.Text.Encoding.UTF8.GetBytes(p.Value);
                             encodedVal = System.Convert.ToBase64String(valBytes);
                             encodedVal = encodedVal.Replace("=", "");
                             encodedVal = encodedVal.Replace("/", "_");
                             encodedVal = encodedVal.Replace("+", "-");
-                        } else {
+                        }
+                        else
+                        {
                             encodedVal = WebUtility.UrlEncode(p.Value);
                             encodedVal = encodedVal.Replace("+", "%20");
                         }

--- a/src/Imgix/UrlBuilder.cs
+++ b/src/Imgix/UrlBuilder.cs
@@ -25,9 +25,6 @@ namespace Imgix
         private static readonly int[] DprRatios = { 1, 2, 3, 4, 5 };
         private static readonly int[] DprQualities = { 75, 50, 35, 23, 20 };
 
-        const String IS_ENCODED = "isEncoded";
-        const String IS_PROXY = "isProxy";
-
         const int MaxWidth = 8192;
         const int MinWidth = 100;
         const double SrcSetWidthTolerance = 0.08;
@@ -100,8 +97,8 @@ namespace Imgix
 
             // Check if path is a proxy path and store type of proxy.
             Dictionary<String, Boolean> proxyStatus = CheckProxyStatus(path);
-            Object pathIsProxy = proxyStatus[IS_PROXY];
-            Object proxyIsEncoded = proxyStatus[IS_ENCODED];
+            Object pathIsProxy = proxyStatus["isProxy"];
+            Object proxyIsEncoded = proxyStatus["isEncoded"];
 
             if (pathIsProxy.Equals(true) && proxyIsEncoded.Equals(false))
             {
@@ -171,26 +168,26 @@ namespace Imgix
 
             if (path.StartsWith(asciiHTTP) || path.StartsWith(asciiHTTPS))
             {
-                status.Add(IS_PROXY, true);
-                status.Add(IS_ENCODED, false);
+                status.Add("isProxy", true);
+                status.Add("isEncoded", false);
 
             }
             else if (path.StartsWith(encodedHTTP) || path.StartsWith(encodedHTTPS))
             {
-                status.Add(IS_PROXY, true);
-                status.Add(IS_ENCODED, true);
+                status.Add("isProxy", true);
+                status.Add("isEncoded", true);
 
             }
             else if (path.StartsWith(encodedHTTPLower) || path.StartsWith(encodedHTTPSLower))
             {
-                status.Add(IS_PROXY, true);
-                status.Add(IS_ENCODED, true);
+                status.Add("isProxy", true);
+                status.Add("isEncoded", true);
 
             }
             else
             {
-                status.Add(IS_PROXY, false);
-                status.Add(IS_ENCODED, false);
+                status.Add("isProxy", false);
+                status.Add("isEncoded", false);
             }
 
             return status;

--- a/tests/Imgix.Tests/Imgix.Tests.csproj
+++ b/tests/Imgix.Tests/Imgix.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NUnitTestAdapter" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Imgix.Tests/UrlBuilderTest.cs
+++ b/tests/Imgix.Tests/UrlBuilderTest.cs
@@ -100,7 +100,7 @@ namespace Imgix.Tests
         }
 
         [TestFixture]
-        public class UrlBuilderBase64EncodesBase64
+        public class UrlBuilderEncodesPathVariants
         {
             UrlBuilder test = new UrlBuilder("demo.imgix.net", includeLibraryParam: false);
             private string path;
@@ -109,7 +109,7 @@ namespace Imgix.Tests
             [TestCase("/&$+,:;=?@#.jpg", "https://demo.imgix.net/%26%24%2B%2C%3A%3B%3D%3F%40%23.jpg")]
             [TestCase("/ <>[]{}|\\^%.jpg", "https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg")]
             [TestCase("/ساندویچ.jpg", "https://demo.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg")]
-            public void UrlBuilderBase64EncodesPathVariant(String path, String expected)
+            public void UrlBuilderEncodesPathVariant(String path, String expected)
             {
                 var actual = test.BuildUrl(path);
                 Assert.AreEqual(expected, actual);

--- a/tests/Imgix.Tests/UrlBuilderTest.cs
+++ b/tests/Imgix.Tests/UrlBuilderTest.cs
@@ -99,6 +99,23 @@ namespace Imgix.Tests
             Assert.AreEqual("https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C", test.BuildUrl("demo.png", parameters));
         }
 
+        [TestFixture]
+        public class UrlBuilderBase64EncodesBase64
+        {
+            UrlBuilder test = new UrlBuilder("demo.imgix.net", includeLibraryParam: false);
+            private string path;
+            private string expected;
+            [Test]
+            [TestCase("/&$+,:;=?@#.jpg", "https://demo.imgix.net/%26%24%2B%2C%3A%3B%3D%3F%40%23.jpg")]
+            [TestCase("/ <>[]{}|\\^%.jpg", "https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg")]
+            [TestCase("/ساندویچ.jpg", "https://demo.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg")]
+            public void UrlBuilderBase64EncodesPathVariant(String path, String expected)
+            {
+                var actual = test.BuildUrl(path);
+                Assert.AreEqual(expected, actual);
+            }
+
+        }
         [Test]
         public void UrlBuilderBase64EncodesBase64ParamVariants()
         {


### PR DESCRIPTION
# Description

This PR includes the following changes:
- fixed ms-dotnettools lint issues
- adds NUnitTestAdapter
- adds vscode dotnet-test test settings
- adds more Base64 encoding tests
- creates the `SanitizePath`, `UrlEncode`, and `Base64Encode` methods to more closely resemble ur-building logic in `imgix-js` and address some path encoding issues.