### PR TITLE
chore(release): 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 ==========
+## 3.2.2 (_April 13, 2021_)
+- fix(BuildUrl): address path encoding lapses ([#40](https://github.com/imgix/imgix-csharp/pull/40))
+
 ## 3.2.1 (_March 24, 2021_)
 - docs: update fixed-width section ([#37](https://github.com/imgix/imgix-csharp/pull/37))
 - fix: dpr srcset when only h param ([#38](https://github.com/imgix/imgix-csharp/pull/38))

--- a/src/Imgix/Imgix.csproj
+++ b/src/Imgix/Imgix.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>Imgix</PackageId>
-    <PackageVersion>3.2.1</PackageVersion>
+    <PackageVersion>3.2.2</PackageVersion>
     <Title>Imgix CSharp Library</Title>
     <Authors>raynjamin; imgix; sherwinski</Authors>
     <Description>A library to help you build client urls for imgix.</Description>

--- a/src/Imgix/Properties/AssemblyInfo.cs
+++ b/src/Imgix/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.1")]
+[assembly: AssemblyVersion("3.2.2")]
 [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
# TTSIA
## 3.2.2 (_April 13, 2021_)
- fix(BuildURl): address path encoding lapses ([#40](https://github.com/imgix/imgix-csharp/pull/40))